### PR TITLE
Creates empty info if there is no properties

### DIFF
--- a/source/engine/export/exporterbim.js
+++ b/source/engine/export/exporterbim.js
@@ -93,8 +93,7 @@ export class ExporterBim extends ExporterBase
                 info[property.name] = PropertyToString (property);
             }
         }
-        if (Object.keys (info).length !== 0) {
-            targetObject.info = info;
-        }
+
+        targetObject.info = info;
     }
 }


### PR DESCRIPTION
Subjective opinion that it makes it easier when all properties are filled 100% of a time, even if it means empty list. To check if after this change it actually creates "info": {} :)