### PR TITLE
Added config + command to build_engine_module to generate .d.ts on building engine module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@simonwep/pickr": "1.8.2",
+				"@types/node": "^18.11.18",
 				"draco3d": "1.5.5",
 				"fflate": "0.7.4",
 				"occt-import-js": "0.0.15",
@@ -29,7 +30,8 @@
 				"oslllo-svg-fixer": "^2.2.0",
 				"rollup": "^3.9.1",
 				"run-python3": "^0.0.4",
-				"svgo": "^3.0.2"
+				"svgo": "^3.0.2",
+				"typescript": "^4.9.4"
 			}
 		},
 		"node_modules/@babel/parser": {
@@ -1273,10 +1275,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-			"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
-			"dev": true
+			"version": "18.11.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+			"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
 		},
 		"node_modules/@xmldom/xmldom": {
 			"version": "0.7.9",
@@ -3200,6 +3201,12 @@
 			"dependencies": {
 				"@types/node": "16.9.1"
 			}
+		},
+		"node_modules/image-q/node_modules/@types/node": {
+			"version": "16.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+			"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+			"dev": true
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -5255,6 +5262,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/typescript": {
+			"version": "4.9.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"node_modules/uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -6399,10 +6419,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-			"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
-			"dev": true
+			"version": "18.11.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+			"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
 		},
 		"@xmldom/xmldom": {
 			"version": "0.7.9",
@@ -7872,6 +7891,14 @@
 			"dev": true,
 			"requires": {
 				"@types/node": "16.9.1"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "16.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+					"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+					"dev": true
+				}
 			}
 		},
 		"import-fresh": {
@@ -9473,6 +9500,12 @@
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true
+		},
+		"typescript": {
+			"version": "4.9.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
 			"dev": true
 		},
 		"uc.micro": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"build_dev": "npm run build_engine_dev && npm run build_website_dev",
 		"build_engine_dev": "npm run update_engine_exports && esbuild source/engine/main.js --bundle --minify --global-name=OV --sourcemap --outfile=build/o3dv.min-dev.js",
 		"build_engine_prod": "npm run update_engine_exports && esbuild source/engine/main.js --bundle --minify --global-name=OV --outfile=build/o3dv.min.js",
-		"build_engine_module": "npm run update_engine_exports && rollup --config tools/rollup.js",
+		"build_engine_module": "npm run update_engine_exports && rollup --config tools/rollup.js && npx tsc",
 		"build_website_dev": "esbuild source/website/index.js --bundle --minify --global-name=OV --sourcemap --outfile=build/o3dv.website.min-dev.js",
 		"build_website_prod": "esbuild source/website/index.js --bundle --minify --global-name=OV --outfile=build/o3dv.website.min.js",
 		"update_engine_exports": "run-python3 tools/update_engine_exports.py"
@@ -69,10 +69,12 @@
 		"oslllo-svg-fixer": "^2.2.0",
 		"rollup": "^3.9.1",
 		"run-python3": "^0.0.4",
-		"svgo": "^3.0.2"
+		"svgo": "^3.0.2",
+		"typescript": "^4.9.4"
 	},
 	"dependencies": {
 		"@simonwep/pickr": "1.8.2",
+		"@types/node": "^18.11.18",
 		"draco3d": "1.5.5",
 		"fflate": "0.7.4",
 		"occt-import-js": "0.0.15",

--- a/source/engine/main.js
+++ b/source/engine/main.js
@@ -1,198 +1,89 @@
-import { IsDefined, ValueOrDefault, CopyObjectAttributes, IsObjectEmpty, EscapeHtmlChars } from './core/core.js';
-import { EventNotifier } from './core/eventnotifier.js';
 import { TaskRunner, RunTaskAsync, RunTasks, RunTasksBatch, WaitWhile } from './core/taskrunner.js';
-import { Exporter } from './export/exporter.js';
-import { Exporter3dm } from './export/exporter3dm.js';
-import { ExportedFile, ExporterBase } from './export/exporterbase.js';
-import { ExporterBim } from './export/exporterbim.js';
-import { ExporterGltf } from './export/exportergltf.js';
-import { ExporterSettings, ExporterModel } from './export/exportermodel.js';
-import { ExporterObj } from './export/exporterobj.js';
-import { ExporterOff } from './export/exporteroff.js';
-import { ExporterPly } from './export/exporterply.js';
-import { ExporterStl } from './export/exporterstl.js';
-import { Box3D, BoundingBoxCalculator3D } from './geometry/box3d.js';
+import { EventNotifier } from './core/eventnotifier.js';
+import { IsDefined, ValueOrDefault, CopyObjectAttributes, IsObjectEmpty, EscapeHtmlChars } from './core/core.js';
+import { GetFileName, GetFileExtension, RequestUrl, ReadFile, TransformFileHostUrls, IsUrl, FileSource, FileFormat } from './io/fileutils.js';
+import { TextWriter } from './io/textwriter.js';
+import { BinaryReader } from './io/binaryreader.js';
+import { BinaryWriter } from './io/binarywriter.js';
+import { SetExternalLibLocation, GetExternalLibPath, LoadExternalLibrary } from './io/externallibs.js';
+import { ArrayBufferToUtf8String, ArrayBufferToAsciiString, AsciiStringToArrayBuffer, Utf8StringToArrayBuffer, Base64DataURIToArrayBuffer, GetFileExtensionFromMimeType, CreateObjectUrl, CreateObjectUrlWithMimeType, RevokeObjectUrl } from './io/bufferutils.js';
+import { CameraValidator, UpVector, Viewer, GetDefaultCamera, TraverseThreeObject, GetShadingTypeOfObject } from './viewer/viewer.js';
+import { EmbeddedViewer, Init3DViewerElementFromUrlList, Init3DViewerElementFromFileList, Init3DViewerElements } from './viewer/embeddedviewer.js';
+import { ViewerModel, EdgeSettings, ViewerMainModel, SetThreeMeshPolygonOffset } from './viewer/viewermodel.js';
+import { MouseInteraction, TouchInteraction, ClickDetector, Navigation, NavigationType } from './viewer/navigation.js';
+import { GetIntegerFromStyle, GetDomElementExternalWidth, GetDomElementExternalHeight, GetDomElementInnerDimensions, GetDomElementClientCoordinates, CreateDomElement, AddDomElement, AddDiv, ClearDomElement, InsertDomElementBefore, InsertDomElementAfter, ShowDomElement, IsDomElementVisible, SetDomElementWidth, SetDomElementHeight, GetDomElementOuterWidth, GetDomElementOuterHeight, SetDomElementOuterWidth, SetDomElementOuterHeight, CreateDiv } from './viewer/domutils.js';
+import { EnvironmentSettings, ShadingModel } from './viewer/shadingmodel.js';
+import { Camera, CameraIsEqual3D, CameraMode } from './viewer/camera.js';
+import { GetTriangleArea, GetTetrahedronSignedVolume, CalculateVolume, CalculateSurfaceArea } from './model/quantities.js';
+import { Mesh } from './model/mesh.js';
+import { TextureMap, MaterialBase, FaceMaterial, PhongMaterial, PhysicalMaterial, TextureMapIsEqual, TextureIsEqual, MaterialType } from './model/material.js';
+import { IsModelEmpty, GetBoundingBox, GetTopology, IsTwoManifold, HasDefaultMaterial, ReplaceDefaultMaterialColor } from './model/modelutils.js';
+import { Object3D, ModelObject3D } from './model/object.js';
+import { Property, PropertyGroup, PropertyToString, PropertyType } from './model/property.js';
+import { GetMeshType, CalculateTriangleNormal, TransformMesh, FlipMeshTrianglesOrientation, MeshType } from './model/meshutils.js';
+import { RGBColor, RGBAColor, ColorComponentFromFloat, ColorComponentToFloat, RGBColorFromFloatComponents, SRGBToLinear, LinearToSRGB, IntegerToHexString, RGBColorToHexString, RGBAColorToHexString, HexStringToRGBColor, HexStringToRGBAColor, ArrayToRGBColor, RGBColorIsEqual } from './model/color.js';
+import { MeshInstanceId, MeshInstance } from './model/meshinstance.js';
+import { Node, NodeType } from './model/node.js';
+import { FinalizeModel, CheckModel } from './model/modelfinalization.js';
+import { GeneratorParams, Generator, GeneratorHelper, GenerateCuboid, GenerateCone, GenerateCylinder, GenerateSphere, GeneratePlatonicSolid } from './model/generator.js';
+import { Model } from './model/model.js';
+import { MeshPrimitiveBuffer, MeshBuffer, ConvertMeshToMeshBuffer } from './model/meshbuffer.js';
+import { Triangle } from './model/triangle.js';
+import { TopologyVertex, TopologyEdge, TopologyTriangleEdge, TopologyTriangle, Topology } from './model/topology.js';
+import { ParameterListBuilder, ParameterListParser, CreateUrlBuilder, CreateUrlParser, CreateModelUrlParameters, ParameterConverter } from './parameters/parameterlist.js';
+import { Quaternion, QuaternionIsEqual, ArrayToQuaternion, QuaternionFromAxisAngle, QuaternionFromXYZ } from './geometry/quaternion.js';
 import { Coord2D, CoordIsEqual2D, AddCoord2D, SubCoord2D, CoordDistance2D } from './geometry/coord2d.js';
 import { Coord3D, CoordIsEqual3D, AddCoord3D, SubCoord3D, CoordDistance3D, DotVector3D, VectorAngle3D, CrossVector3D, VectorLength3D, ArrayToCoord3D } from './geometry/coord3d.js';
 import { Coord4D } from './geometry/coord4d.js';
-import { IsZero, IsLower, IsGreater, IsLowerOrEqual, IsGreaterOrEqual, IsEqual, IsEqualEps, IsPositive, IsNegative, Eps, BigEps, RadDeg, DegRad, Direction } from './geometry/geometry.js';
 import { Matrix, MatrixIsEqual } from './geometry/matrix.js';
-import { OctreeNode, Octree } from './geometry/octree.js';
-import { Quaternion, QuaternionIsEqual, ArrayToQuaternion, QuaternionFromAxisAngle, QuaternionFromXYZ } from './geometry/quaternion.js';
 import { Transformation, TransformationIsEqual } from './geometry/transformation.js';
+import { Box3D, BoundingBoxCalculator3D } from './geometry/box3d.js';
+import { OctreeNode, Octree } from './geometry/octree.js';
 import { BezierTweenFunction, LinearTweenFunction, ParabolicTweenFunction, TweenCoord3D } from './geometry/tween.js';
-import { ImportSettings, ImportError, ImportResult, ImporterFileAccessor, Importer, ImportErrorCode } from './import/importer.js';
-import { Importer3dm } from './import/importer3dm.js';
-import { Importer3ds } from './import/importer3ds.js';
-import { ImporterBase } from './import/importerbase.js';
-import { ImporterBim } from './import/importerbim.js';
-import { ImporterFcstd } from './import/importerfcstd.js';
-import { InputFile, ImporterFile, ImporterFileList, InputFilesFromUrls, InputFilesFromFileObjects } from './import/importerfiles.js';
-import { ImporterGltf } from './import/importergltf.js';
-import { ImporterIfc } from './import/importerifc.js';
-import { ImporterObj } from './import/importerobj.js';
-import { ImporterOcct } from './import/importerocct.js';
-import { ImporterOff } from './import/importeroff.js';
-import { ImporterPly } from './import/importerply.js';
-import { ImporterStl } from './import/importerstl.js';
-import { ImporterThreeSvg } from './import/importersvg.js';
-import { ImporterThreeBase, ImporterThreeFbx, ImporterThreeDae, ImporterThreeWrl, ImporterThree3mf } from './import/importerthree.js';
+import { IsZero, IsLower, IsGreater, IsLowerOrEqual, IsGreaterOrEqual, IsEqual, IsEqualEps, IsPositive, IsNegative, Eps, BigEps, RadDeg, DegRad, Direction } from './geometry/geometry.js';
+import { ExporterBim } from './export/exporterbim.js';
+import { Exporter } from './export/exporter.js';
+import { ExporterObj } from './export/exporterobj.js';
+import { ExporterSettings, ExporterModel } from './export/exportermodel.js';
+import { ExportedFile, ExporterBase } from './export/exporterbase.js';
+import { ExporterStl } from './export/exporterstl.js';
+import { ExporterOff } from './export/exporteroff.js';
+import { Exporter3dm } from './export/exporter3dm.js';
+import { ExporterPly } from './export/exporterply.js';
+import { ExporterGltf } from './export/exportergltf.js';
 import { ColorToMaterialConverter, NameFromLine, ParametersFromLine, ReadLines, IsPowerOfTwo, NextPowerOfTwo, UpdateMaterialTransparency } from './import/importerutils.js';
-import { BinaryReader } from './io/binaryreader.js';
-import { BinaryWriter } from './io/binarywriter.js';
-import { ArrayBufferToUtf8String, ArrayBufferToAsciiString, AsciiStringToArrayBuffer, Utf8StringToArrayBuffer, Base64DataURIToArrayBuffer, GetFileExtensionFromMimeType, CreateObjectUrl, CreateObjectUrlWithMimeType, RevokeObjectUrl } from './io/bufferutils.js';
-import { SetExternalLibLocation, GetExternalLibPath, LoadExternalLibrary } from './io/externallibs.js';
-import { GetFileName, GetFileExtension, RequestUrl, ReadFile, TransformFileHostUrls, IsUrl, FileSource, FileFormat } from './io/fileutils.js';
-import { TextWriter } from './io/textwriter.js';
-import { RGBColor, RGBAColor, ColorComponentFromFloat, ColorComponentToFloat, RGBColorFromFloatComponents, SRGBToLinear, LinearToSRGB, IntegerToHexString, RGBColorToHexString, RGBAColorToHexString, HexStringToRGBColor, HexStringToRGBAColor, ArrayToRGBColor, RGBColorIsEqual } from './model/color.js';
-import { GeneratorParams, Generator, GeneratorHelper, GenerateCuboid, GenerateCone, GenerateCylinder, GenerateSphere, GeneratePlatonicSolid } from './model/generator.js';
-import { TextureMap, MaterialBase, FaceMaterial, PhongMaterial, PhysicalMaterial, TextureMapIsEqual, TextureIsEqual, MaterialType } from './model/material.js';
-import { Mesh } from './model/mesh.js';
-import { MeshPrimitiveBuffer, MeshBuffer, ConvertMeshToMeshBuffer } from './model/meshbuffer.js';
-import { MeshInstanceId, MeshInstance } from './model/meshinstance.js';
-import { GetMeshType, CalculateTriangleNormal, TransformMesh, FlipMeshTrianglesOrientation, MeshType } from './model/meshutils.js';
-import { Model } from './model/model.js';
-import { FinalizeModel, CheckModel } from './model/modelfinalization.js';
-import { IsModelEmpty, GetBoundingBox, GetTopology, IsTwoManifold, HasDefaultMaterial, ReplaceDefaultMaterialColor } from './model/modelutils.js';
-import { Node, NodeType } from './model/node.js';
-import { Object3D, ModelObject3D } from './model/object.js';
-import { Property, PropertyGroup, PropertyToString, PropertyType } from './model/property.js';
-import { GetTriangleArea, GetTetrahedronSignedVolume, CalculateVolume, CalculateSurfaceArea } from './model/quantities.js';
-import { TopologyVertex, TopologyEdge, TopologyTriangleEdge, TopologyTriangle, Topology } from './model/topology.js';
-import { Triangle } from './model/triangle.js';
-import { ParameterListBuilder, ParameterListParser, CreateUrlBuilder, CreateUrlParser, CreateModelUrlParameters, ParameterConverter } from './parameters/parameterlist.js';
+import { ImporterThreeSvg } from './import/importersvg.js';
+import { ImporterGltf } from './import/importergltf.js';
+import { ImporterBim } from './import/importerbim.js';
+import { ImporterObj } from './import/importerobj.js';
+import { Importer3ds } from './import/importer3ds.js';
+import { ImporterStl } from './import/importerstl.js';
+import { ImporterOcct } from './import/importerocct.js';
+import { ImporterFcstd } from './import/importerfcstd.js';
+import { ImportSettings, ImportError, ImportResult, ImporterFileAccessor, Importer, ImportErrorCode } from './import/importer.js';
+import { InputFile, ImporterFile, ImporterFileList, InputFilesFromUrls, InputFilesFromFileObjects } from './import/importerfiles.js';
+import { Importer3dm } from './import/importer3dm.js';
+import { ImporterOff } from './import/importeroff.js';
+import { ImporterThreeBase, ImporterThreeFbx, ImporterThreeDae, ImporterThreeWrl, ImporterThree3mf } from './import/importerthree.js';
+import { ImporterBase } from './import/importerbase.js';
+import { ImporterPly } from './import/importerply.js';
+import { ImporterIfc } from './import/importerifc.js';
 import { ModelToThreeConversionParams, ModelToThreeConversionOutput, ThreeConversionStateHandler, ThreeNodeTree, ConvertModelToThreeObject } from './threejs/threeconverter.js';
 import { ThreeModelLoader } from './threejs/threemodelloader.js';
 import { HasHighpDriverIssue, GetShadingType, ConvertThreeColorToColor, ConvertColorToThreeColor, ConvertThreeGeometryToMesh, DisposeThreeObjects, ShadingType } from './threejs/threeutils.js';
-import { Camera, CameraIsEqual3D, CameraMode } from './viewer/camera.js';
-import { GetIntegerFromStyle, GetDomElementExternalWidth, GetDomElementExternalHeight, GetDomElementInnerDimensions, GetDomElementClientCoordinates, CreateDomElement, AddDomElement, AddDiv, ClearDomElement, InsertDomElementBefore, InsertDomElementAfter, ShowDomElement, IsDomElementVisible, SetDomElementWidth, SetDomElementHeight, GetDomElementOuterWidth, GetDomElementOuterHeight, SetDomElementOuterWidth, SetDomElementOuterHeight, CreateDiv } from './viewer/domutils.js';
-import { EmbeddedViewer, Init3DViewerElementFromUrlList, Init3DViewerElementFromFileList, Init3DViewerElements } from './viewer/embeddedviewer.js';
-import { MouseInteraction, TouchInteraction, ClickDetector, Navigation, NavigationType } from './viewer/navigation.js';
-import { EnvironmentSettings, ShadingModel } from './viewer/shadingmodel.js';
-import { CameraValidator, UpVector, Viewer, GetDefaultCamera, TraverseThreeObject, GetShadingTypeOfObject } from './viewer/viewer.js';
-import { ViewerModel, EdgeSettings, ViewerMainModel, SetThreeMeshPolygonOffset } from './viewer/viewermodel.js';
 
 export {
-    IsDefined,
-    ValueOrDefault,
-    CopyObjectAttributes,
-    IsObjectEmpty,
-    EscapeHtmlChars,
-    EventNotifier,
     TaskRunner,
     RunTaskAsync,
     RunTasks,
     RunTasksBatch,
     WaitWhile,
-    Exporter,
-    Exporter3dm,
-    ExportedFile,
-    ExporterBase,
-    ExporterBim,
-    ExporterGltf,
-    ExporterSettings,
-    ExporterModel,
-    ExporterObj,
-    ExporterOff,
-    ExporterPly,
-    ExporterStl,
-    Box3D,
-    BoundingBoxCalculator3D,
-    Coord2D,
-    CoordIsEqual2D,
-    AddCoord2D,
-    SubCoord2D,
-    CoordDistance2D,
-    Coord3D,
-    CoordIsEqual3D,
-    AddCoord3D,
-    SubCoord3D,
-    CoordDistance3D,
-    DotVector3D,
-    VectorAngle3D,
-    CrossVector3D,
-    VectorLength3D,
-    ArrayToCoord3D,
-    Coord4D,
-    IsZero,
-    IsLower,
-    IsGreater,
-    IsLowerOrEqual,
-    IsGreaterOrEqual,
-    IsEqual,
-    IsEqualEps,
-    IsPositive,
-    IsNegative,
-    Eps,
-    BigEps,
-    RadDeg,
-    DegRad,
-    Direction,
-    Matrix,
-    MatrixIsEqual,
-    OctreeNode,
-    Octree,
-    Quaternion,
-    QuaternionIsEqual,
-    ArrayToQuaternion,
-    QuaternionFromAxisAngle,
-    QuaternionFromXYZ,
-    Transformation,
-    TransformationIsEqual,
-    BezierTweenFunction,
-    LinearTweenFunction,
-    ParabolicTweenFunction,
-    TweenCoord3D,
-    ImportSettings,
-    ImportError,
-    ImportResult,
-    ImporterFileAccessor,
-    Importer,
-    ImportErrorCode,
-    Importer3dm,
-    Importer3ds,
-    ImporterBase,
-    ImporterBim,
-    ImporterFcstd,
-    InputFile,
-    ImporterFile,
-    ImporterFileList,
-    InputFilesFromUrls,
-    InputFilesFromFileObjects,
-    ImporterGltf,
-    ImporterIfc,
-    ImporterObj,
-    ImporterOcct,
-    ImporterOff,
-    ImporterPly,
-    ImporterStl,
-    ImporterThreeSvg,
-    ImporterThreeBase,
-    ImporterThreeFbx,
-    ImporterThreeDae,
-    ImporterThreeWrl,
-    ImporterThree3mf,
-    ColorToMaterialConverter,
-    NameFromLine,
-    ParametersFromLine,
-    ReadLines,
-    IsPowerOfTwo,
-    NextPowerOfTwo,
-    UpdateMaterialTransparency,
-    BinaryReader,
-    BinaryWriter,
-    ArrayBufferToUtf8String,
-    ArrayBufferToAsciiString,
-    AsciiStringToArrayBuffer,
-    Utf8StringToArrayBuffer,
-    Base64DataURIToArrayBuffer,
-    GetFileExtensionFromMimeType,
-    CreateObjectUrl,
-    CreateObjectUrlWithMimeType,
-    RevokeObjectUrl,
-    SetExternalLibLocation,
-    GetExternalLibPath,
-    LoadExternalLibrary,
+    EventNotifier,
+    IsDefined,
+    ValueOrDefault,
+    CopyObjectAttributes,
+    IsObjectEmpty,
+    EscapeHtmlChars,
     GetFileName,
     GetFileExtension,
     RequestUrl,
@@ -202,96 +93,39 @@ export {
     FileSource,
     FileFormat,
     TextWriter,
-    RGBColor,
-    RGBAColor,
-    ColorComponentFromFloat,
-    ColorComponentToFloat,
-    RGBColorFromFloatComponents,
-    SRGBToLinear,
-    LinearToSRGB,
-    IntegerToHexString,
-    RGBColorToHexString,
-    RGBAColorToHexString,
-    HexStringToRGBColor,
-    HexStringToRGBAColor,
-    ArrayToRGBColor,
-    RGBColorIsEqual,
-    GeneratorParams,
-    Generator,
-    GeneratorHelper,
-    GenerateCuboid,
-    GenerateCone,
-    GenerateCylinder,
-    GenerateSphere,
-    GeneratePlatonicSolid,
-    TextureMap,
-    MaterialBase,
-    FaceMaterial,
-    PhongMaterial,
-    PhysicalMaterial,
-    TextureMapIsEqual,
-    TextureIsEqual,
-    MaterialType,
-    Mesh,
-    MeshPrimitiveBuffer,
-    MeshBuffer,
-    ConvertMeshToMeshBuffer,
-    MeshInstanceId,
-    MeshInstance,
-    GetMeshType,
-    CalculateTriangleNormal,
-    TransformMesh,
-    FlipMeshTrianglesOrientation,
-    MeshType,
-    Model,
-    FinalizeModel,
-    CheckModel,
-    IsModelEmpty,
-    GetBoundingBox,
-    GetTopology,
-    IsTwoManifold,
-    HasDefaultMaterial,
-    ReplaceDefaultMaterialColor,
-    Node,
-    NodeType,
-    Object3D,
-    ModelObject3D,
-    Property,
-    PropertyGroup,
-    PropertyToString,
-    PropertyType,
-    GetTriangleArea,
-    GetTetrahedronSignedVolume,
-    CalculateVolume,
-    CalculateSurfaceArea,
-    TopologyVertex,
-    TopologyEdge,
-    TopologyTriangleEdge,
-    TopologyTriangle,
-    Topology,
-    Triangle,
-    ParameterListBuilder,
-    ParameterListParser,
-    CreateUrlBuilder,
-    CreateUrlParser,
-    CreateModelUrlParameters,
-    ParameterConverter,
-    ModelToThreeConversionParams,
-    ModelToThreeConversionOutput,
-    ThreeConversionStateHandler,
-    ThreeNodeTree,
-    ConvertModelToThreeObject,
-    ThreeModelLoader,
-    HasHighpDriverIssue,
-    GetShadingType,
-    ConvertThreeColorToColor,
-    ConvertColorToThreeColor,
-    ConvertThreeGeometryToMesh,
-    DisposeThreeObjects,
-    ShadingType,
-    Camera,
-    CameraIsEqual3D,
-    CameraMode,
+    BinaryReader,
+    BinaryWriter,
+    SetExternalLibLocation,
+    GetExternalLibPath,
+    LoadExternalLibrary,
+    ArrayBufferToUtf8String,
+    ArrayBufferToAsciiString,
+    AsciiStringToArrayBuffer,
+    Utf8StringToArrayBuffer,
+    Base64DataURIToArrayBuffer,
+    GetFileExtensionFromMimeType,
+    CreateObjectUrl,
+    CreateObjectUrlWithMimeType,
+    RevokeObjectUrl,
+    CameraValidator,
+    UpVector,
+    Viewer,
+    GetDefaultCamera,
+    TraverseThreeObject,
+    GetShadingTypeOfObject,
+    EmbeddedViewer,
+    Init3DViewerElementFromUrlList,
+    Init3DViewerElementFromFileList,
+    Init3DViewerElements,
+    ViewerModel,
+    EdgeSettings,
+    ViewerMainModel,
+    SetThreeMeshPolygonOffset,
+    MouseInteraction,
+    TouchInteraction,
+    ClickDetector,
+    Navigation,
+    NavigationType,
     GetIntegerFromStyle,
     GetDomElementExternalWidth,
     GetDomElementExternalHeight,
@@ -312,25 +146,191 @@ export {
     SetDomElementOuterWidth,
     SetDomElementOuterHeight,
     CreateDiv,
-    EmbeddedViewer,
-    Init3DViewerElementFromUrlList,
-    Init3DViewerElementFromFileList,
-    Init3DViewerElements,
-    MouseInteraction,
-    TouchInteraction,
-    ClickDetector,
-    Navigation,
-    NavigationType,
     EnvironmentSettings,
     ShadingModel,
-    CameraValidator,
-    UpVector,
-    Viewer,
-    GetDefaultCamera,
-    TraverseThreeObject,
-    GetShadingTypeOfObject,
-    ViewerModel,
-    EdgeSettings,
-    ViewerMainModel,
-    SetThreeMeshPolygonOffset
+    Camera,
+    CameraIsEqual3D,
+    CameraMode,
+    GetTriangleArea,
+    GetTetrahedronSignedVolume,
+    CalculateVolume,
+    CalculateSurfaceArea,
+    Mesh,
+    TextureMap,
+    MaterialBase,
+    FaceMaterial,
+    PhongMaterial,
+    PhysicalMaterial,
+    TextureMapIsEqual,
+    TextureIsEqual,
+    MaterialType,
+    IsModelEmpty,
+    GetBoundingBox,
+    GetTopology,
+    IsTwoManifold,
+    HasDefaultMaterial,
+    ReplaceDefaultMaterialColor,
+    Object3D,
+    ModelObject3D,
+    Property,
+    PropertyGroup,
+    PropertyToString,
+    PropertyType,
+    GetMeshType,
+    CalculateTriangleNormal,
+    TransformMesh,
+    FlipMeshTrianglesOrientation,
+    MeshType,
+    RGBColor,
+    RGBAColor,
+    ColorComponentFromFloat,
+    ColorComponentToFloat,
+    RGBColorFromFloatComponents,
+    SRGBToLinear,
+    LinearToSRGB,
+    IntegerToHexString,
+    RGBColorToHexString,
+    RGBAColorToHexString,
+    HexStringToRGBColor,
+    HexStringToRGBAColor,
+    ArrayToRGBColor,
+    RGBColorIsEqual,
+    MeshInstanceId,
+    MeshInstance,
+    Node,
+    NodeType,
+    FinalizeModel,
+    CheckModel,
+    GeneratorParams,
+    Generator,
+    GeneratorHelper,
+    GenerateCuboid,
+    GenerateCone,
+    GenerateCylinder,
+    GenerateSphere,
+    GeneratePlatonicSolid,
+    Model,
+    MeshPrimitiveBuffer,
+    MeshBuffer,
+    ConvertMeshToMeshBuffer,
+    Triangle,
+    TopologyVertex,
+    TopologyEdge,
+    TopologyTriangleEdge,
+    TopologyTriangle,
+    Topology,
+    ParameterListBuilder,
+    ParameterListParser,
+    CreateUrlBuilder,
+    CreateUrlParser,
+    CreateModelUrlParameters,
+    ParameterConverter,
+    Quaternion,
+    QuaternionIsEqual,
+    ArrayToQuaternion,
+    QuaternionFromAxisAngle,
+    QuaternionFromXYZ,
+    Coord2D,
+    CoordIsEqual2D,
+    AddCoord2D,
+    SubCoord2D,
+    CoordDistance2D,
+    Coord3D,
+    CoordIsEqual3D,
+    AddCoord3D,
+    SubCoord3D,
+    CoordDistance3D,
+    DotVector3D,
+    VectorAngle3D,
+    CrossVector3D,
+    VectorLength3D,
+    ArrayToCoord3D,
+    Coord4D,
+    Matrix,
+    MatrixIsEqual,
+    Transformation,
+    TransformationIsEqual,
+    Box3D,
+    BoundingBoxCalculator3D,
+    OctreeNode,
+    Octree,
+    BezierTweenFunction,
+    LinearTweenFunction,
+    ParabolicTweenFunction,
+    TweenCoord3D,
+    IsZero,
+    IsLower,
+    IsGreater,
+    IsLowerOrEqual,
+    IsGreaterOrEqual,
+    IsEqual,
+    IsEqualEps,
+    IsPositive,
+    IsNegative,
+    Eps,
+    BigEps,
+    RadDeg,
+    DegRad,
+    Direction,
+    ExporterBim,
+    Exporter,
+    ExporterObj,
+    ExporterSettings,
+    ExporterModel,
+    ExportedFile,
+    ExporterBase,
+    ExporterStl,
+    ExporterOff,
+    Exporter3dm,
+    ExporterPly,
+    ExporterGltf,
+    ColorToMaterialConverter,
+    NameFromLine,
+    ParametersFromLine,
+    ReadLines,
+    IsPowerOfTwo,
+    NextPowerOfTwo,
+    UpdateMaterialTransparency,
+    ImporterThreeSvg,
+    ImporterGltf,
+    ImporterBim,
+    ImporterObj,
+    Importer3ds,
+    ImporterStl,
+    ImporterOcct,
+    ImporterFcstd,
+    ImportSettings,
+    ImportError,
+    ImportResult,
+    ImporterFileAccessor,
+    Importer,
+    ImportErrorCode,
+    InputFile,
+    ImporterFile,
+    ImporterFileList,
+    InputFilesFromUrls,
+    InputFilesFromFileObjects,
+    Importer3dm,
+    ImporterOff,
+    ImporterThreeBase,
+    ImporterThreeFbx,
+    ImporterThreeDae,
+    ImporterThreeWrl,
+    ImporterThree3mf,
+    ImporterBase,
+    ImporterPly,
+    ImporterIfc,
+    ModelToThreeConversionParams,
+    ModelToThreeConversionOutput,
+    ThreeConversionStateHandler,
+    ThreeNodeTree,
+    ConvertModelToThreeObject,
+    ThreeModelLoader,
+    HasHighpDriverIssue,
+    GetShadingType,
+    ConvertThreeColorToColor,
+    ConvertColorToThreeColor,
+    ConvertThreeGeometryToMesh,
+    DisposeThreeObjects,
+    ShadingType
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  // Change this to match your project
+  "include": ["build/**/*"],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    // "outDir": "build",
+    // go to js file when using IDE functions like
+    // "Go to Definition" in VSCode
+    "declarationMap": true
+  }
+}


### PR DESCRIPTION
This should solve the issues raised in the prior pull request. Added the requisite setup to generate the .d.ts files form the o3dv.module.js file and place them in the same folder. When you run `build_engine_module`, it'll run `npx tsc` after the other commands and generate the .d.ts files. If you could test this out to check it works, that'd be great