### PR TITLE
Update exporterbim.js force color to integer

### DIFF
--- a/source/engine/export/exporterbim.js
+++ b/source/engine/export/exporterbim.js
@@ -83,10 +83,10 @@ export class ExporterBim extends ExporterBase
                 let triangle = mesh.GetTriangle (i);
                 let material = exporterModel.GetMaterial (triangle.mat);
                 let faceColor = {
-                    r : material.color.r,
-                    g : material.color.g,
-                    b : material.color.b,
-                    a : ColorComponentFromFloat (material.opacity),
+                    r : Math.round(material.color.r),
+                    g : Math.round(material.color.g),
+                    b : Math.round(material.color.b),
+                    a : Math.round(ColorComponentFromFloat (material.opacity)),
                 };
                 faceColors.push (faceColor.r, faceColor.g, faceColor.b, faceColor.a);
                 if (hasOnlyOneColor) {

--- a/source/engine/export/exporterbim.js
+++ b/source/engine/export/exporterbim.js
@@ -83,10 +83,10 @@ export class ExporterBim extends ExporterBase
                 let triangle = mesh.GetTriangle (i);
                 let material = exporterModel.GetMaterial (triangle.mat);
                 let faceColor = {
-                    r : Math.round(material.color.r),
-                    g : Math.round(material.color.g),
-                    b : Math.round(material.color.b),
-                    a : Math.round(ColorComponentFromFloat (material.opacity)),
+                    r : Math.round (material.color.r),
+                    g : Math.round (material.color.g),
+                    b : Math.round (material.color.b),
+                    a : ColorComponentFromFloat (material.opacity),
                 };
                 faceColors.push (faceColor.r, faceColor.g, faceColor.b, faceColor.a);
                 if (hasOnlyOneColor) {


### PR DESCRIPTION
Force RGB to round to be an integer.

Depending on the material color, the viewer export dotbim file with color in double format.

The color need to be integer.
* https://github.com/paireks/dotbim#color-and-face_colors