### PR TITLE
Adding a highlight tool 

### DIFF
--- a/source/engine/viewer/navigation.js
+++ b/source/engine/viewer/navigation.js
@@ -283,7 +283,7 @@ export class Navigation
 		this.onContext = onContext;
 	}
 
-	EnableCameraMovement(enable) {
+	EnableCameraMovement (enable) {
         this.enableCameraMovement = enable;
     }
 
@@ -376,6 +376,7 @@ export class Navigation
 		this.clickDetector.Start (this.mouse.GetPosition ());
 
 		if (!this.enableCameraMovement) {
+			console.log('im here heehee OnMouseDowns')
             this.isMouseDown = true;
         }
 	}
@@ -464,8 +465,11 @@ export class Navigation
 		this.clickDetector.Move (this.touch.GetPosition ());
 		if (!this.touch.IsFingerDown ()) {
 			return;
+		} 
+		else if (!this.enableCameraMovement) {
+			return;
 		}
-
+		
 		let moveDiff = this.touch.GetMoveDiff ();
 		let distanceDiff = this.touch.GetDistanceDiff ();
 		let fingerCount = this.touch.GetFingerCount ();

--- a/source/engine/viewer/navigation.js
+++ b/source/engine/viewer/navigation.js
@@ -242,6 +242,7 @@ export class Navigation
 		this.camera = camera;
 		this.callbacks = callbacks;
 		this.navigationMode = NavigationMode.FixedUpVector;
+		this.enableCameraMovement = true;
 
 		this.mouse = new MouseInteraction ();
 		this.touch = new TouchInteraction ();
@@ -281,6 +282,10 @@ export class Navigation
 	{
 		this.onContext = onContext;
 	}
+
+	EnableCameraMovement(enable) {
+        this.enableCameraMovement = enable;
+    }
 
 	GetNavigationMode ()
 	{
@@ -369,6 +374,10 @@ export class Navigation
 
 		this.mouse.Down (this.canvas, ev);
 		this.clickDetector.Start (this.mouse.GetPosition ());
+
+		if (!this.enableCameraMovement) {
+            this.isMouseDown = true;
+        }
 	}
 
 	OnMouseMove (ev)
@@ -384,9 +393,12 @@ export class Navigation
 			return;
 		}
 
+		if (!this.enableCameraMovement) {
+            return;
+        }
+
 		let moveDiff = this.mouse.GetMoveDiff ();
 		let mouseButton = this.mouse.GetButton ();
-
 		let navigationType = NavigationType.None;
 		if (mouseButton === 1) {
 			if (ev.ctrlKey) {
@@ -424,6 +436,10 @@ export class Navigation
 			let mouseCoords = this.mouse.GetPosition ();
 			this.Click (ev.which, mouseCoords);
 		}
+
+		if (!this.enableCameraMovement) {
+            this.isMouseDown = false;
+        }
 	}
 
 	OnMouseLeave (ev)

--- a/source/engine/viewer/viewer.js
+++ b/source/engine/viewer/viewer.js
@@ -433,6 +433,21 @@ export class Viewer
         this.Render ();
     }
 
+    RemoveExtraObject (object)
+    {
+        if (this.extraModel && typeof this.extraModel.GetObjects === 'function') {
+            const index = this.extraModel.GetObjects ().indexOf (object);
+            if (index !== -1) {
+                this.extraModel.RemoveObject (object);
+                this.Render ();
+            } else {
+                console.log('Object not found in the list')
+            }
+        } else {
+            console.error('this.extraModel or GetObjects is not available');
+        }
+    }
+
     Clear ()
     {
         this.mainModel.Clear ();

--- a/source/engine/viewer/viewermodel.js
+++ b/source/engine/viewer/viewermodel.js
@@ -64,6 +64,22 @@ export class ViewerModel
         this.rootObject.add (object);
     }
 
+    RemoveObject(object) {
+        if (this.rootObject) {
+            this.rootObject.remove(object);
+        }
+    }
+    
+    GetObjects() {
+        let objects = [];
+        this.rootObject.traverse((obj) => {
+            if (obj !== this.rootObject) {
+                objects.push(obj);
+            }
+        });
+        return objects;
+    }
+
     Traverse (enumerator)
     {
         if (this.rootObject === null) {
@@ -81,10 +97,9 @@ export class ViewerModel
         }
     }
 
-    Clear ()
-    {
-        DisposeThreeObjects (this.rootObject);
-        this.scene.remove (this.rootObject);
+    Clear() {
+        DisposeThreeObjects(this.rootObject);
+        this.scene.remove(this.rootObject);
         this.rootObject = null;
     }
 }
@@ -125,6 +140,7 @@ export class ViewerMainModel
 
         this.mainModel = new ViewerModel (this.scene);
         this.edgeModel = new ViewerModel (this.scene);
+        this.highlightModel = new ViewerModel (this.scene);
 
         this.edgeSettings = new EdgeSettings (false, new RGBColor (0, 0, 0), 1);
         this.hasLines = false;

--- a/source/website/highlighttool.js
+++ b/source/website/highlighttool.js
@@ -1,0 +1,240 @@
+import * as THREE from 'three';
+import { AddDiv, ClearDomElement } from '../engine/viewer/domutils.js';
+import { IntersectionMode } from '../engine/viewer/viewermodel.js';
+import { DisposeThreeObjects } from '../engine/threejs/threeutils.js';
+
+export class HighlightTool {
+    constructor(viewer, settings) {
+        this.viewer = viewer;
+        this.settings = settings;
+        this.isActive = false;
+        this.isMouseDown = false;
+        this.mouseButton = null;
+        this.highlightColor = new THREE.Color(1, 0, 0); // Default red color
+        this.highlightMeshes = [];
+        this.panel = null;
+        this.button = null;
+
+        this.InitEvents();
+    }
+
+    InitEvents() {
+        window.addEventListener('mousedown', (event) => {
+            if (this.isActive) {
+                this.isMouseDown = true;
+                this.mouseButton = event.button;
+            }
+        });
+
+        window.addEventListener('mouseup', (event) => {
+            if (this.isActive) {
+                this.isMouseDown = false;
+                this.mouseButton = null;
+            }
+        });
+    }
+
+    SetButton(button) {
+        this.button = button;
+    }
+
+    IsActive() {
+        return this.isActive;
+    }
+
+    SetActive(isActive) {
+        if (this.isActive === isActive) {
+            return;
+        }
+        this.isActive = isActive;
+        this.button.SetSelected(isActive);
+
+        this.viewer.navigation.EnableCameraMovement(!isActive);
+
+        if (this.isActive) {
+            this.panel = AddDiv(document.body, 'ov_highlight_panel');
+            this.UpdatePanel();
+            this.Resize();
+        } else {
+            this.panel.remove();
+        }
+    }
+
+    Click(mouseCoordinates, button) {
+        let intersection = this.viewer.GetMeshIntersectionUnderMouse(IntersectionMode.MeshOnly, mouseCoordinates);
+        if (intersection === null) {
+            return;
+        }
+
+        if (button === 0) {
+            console.log('Left click');
+            this.ApplyHighlight(intersection);
+        } else if (button === 2) {
+            console.log('Right click');
+            this.RemoveHighlight(intersection);
+        }
+
+        this.UpdatePanel();
+    }
+
+    MouseMove(mouseCoordinates) {
+        if (!this.isMouseDown) {
+            return;
+        }
+
+        let intersection = this.viewer.GetMeshIntersectionUnderMouse(IntersectionMode.MeshOnly, mouseCoordinates);
+        if (intersection === null) {
+            return;
+        }
+
+        if (this.mouseButton === 0) {
+            console.log('Mouse move highlighting');
+            this.ApplyHighlight(intersection);
+        } else if (this.mouseButton === 2) {
+            console.log('Mouse move unhighlighting');
+            this.RemoveHighlight(intersection);
+        }
+
+        this.viewer.Render();
+    }
+
+    ApplyHighlight(intersection) {
+        let highlightMesh = this.GenerateHighlightMesh(intersection);
+        this.highlightMeshes.push(highlightMesh);
+        this.viewer.AddExtraObject(highlightMesh);
+    }
+
+    RemoveHighlight(intersection) {
+        let meshToRemove = this.highlightMeshes.find((mesh) => {
+            return this.IsIntersectionWithinBoundingBox(intersection, mesh);
+        });
+
+        if (meshToRemove) {
+            this.viewer.RemoveExtraObject(meshToRemove);
+            this.highlightMeshes = this.highlightMeshes.filter((mesh) => mesh !== meshToRemove);
+            this.DisposeHighlightMesh(meshToRemove); // Properly dispose of the mesh
+            this.viewer.Render();
+        }
+    }
+
+    DisposeHighlightMesh(mesh) {
+        DisposeThreeObjects(mesh);
+        this.viewer.scene.remove (mesh);
+        this.viewer.Render();  
+    }
+
+    IsIntersectionWithinBoundingBox(intersection, mesh) {
+        let boundingBox = new THREE.Box3().setFromObject(mesh);
+        let result = boundingBox.containsPoint(intersection.point);
+        return result;
+    }
+
+    IsIntersectionWithinMesh(intersection, mesh) {
+        let positions = mesh.geometry.attributes.position.array;
+        let threshold = 0.1; // Adjust the threshold as needed
+
+        for (let i = 0; i < positions.length; i += 9) {
+            let a = new THREE.Vector3(positions[i], positions[i + 1], positions[i + 2]);
+            let b = new THREE.Vector3(positions[i + 3], positions[i + 4], positions[i + 5]);
+            let c = new THREE.Vector3(positions[i + 6], positions[i + 7], positions[i + 8]);
+
+            if (this.ArePointsClose(intersection.point, a, threshold) ||
+                this.ArePointsClose(intersection.point, b, threshold) ||
+                this.ArePointsClose(intersection.point, c, threshold)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    ArePointsClose(point1, point2, threshold) {
+        return point1.distanceTo(point2) < threshold;
+    }
+
+    GenerateHighlightMesh(intersection) {
+        let mesh = intersection.object;
+        let highlightMaterial = new THREE.MeshPhongMaterial({
+            color: this.highlightColor,
+            transparent: true,
+            opacity: 0.5,
+            side: THREE.DoubleSide,
+            depthTest: true,
+            depthWrite: false,
+            polygonOffset: true,
+            polygonOffsetFactor: -1,
+            polygonOffsetUnits: -1
+        });
+
+        let highlightGeometry = new THREE.BufferGeometry();
+        let positions = mesh.geometry.attributes.position;
+
+        let a = new THREE.Vector3(), b = new THREE.Vector3(), c = new THREE.Vector3();
+        a.fromBufferAttribute(positions, intersection.face.a);
+        b.fromBufferAttribute(positions, intersection.face.b);
+        c.fromBufferAttribute(positions, intersection.face.c);
+
+        highlightGeometry.setAttribute('position', new THREE.Float32BufferAttribute([
+            a.x, a.y, a.z,
+            b.x, b.y, b.z,
+            c.x, c.y, c.z
+        ], 3));
+
+        let normal = new THREE.Vector3();
+        normal.crossVectors(b.clone().sub(a), c.clone().sub(a)).normalize();
+        highlightGeometry.setAttribute('normal', new THREE.Float32BufferAttribute([
+            normal.x, normal.y, normal.z,
+            normal.x, normal.y, normal.z,
+            normal.x, normal.y, normal.z
+        ], 3));
+
+        let highlightMesh = new THREE.Mesh(highlightGeometry, highlightMaterial);
+        highlightMesh.applyMatrix4(mesh.matrixWorld);
+        let offset = normal.multiplyScalar(0.001);
+        highlightMesh.position.add(offset);
+
+        return highlightMesh;
+    }
+
+    UpdatePanel() {
+        ClearDomElement(this.panel);
+
+        let colorPicker = AddDiv(this.panel, 'ov_highlight_color_picker');
+        colorPicker.innerHTML = '<input type="color" id="highlight-color" value="#ff0000">';
+        colorPicker.addEventListener('change', (event) => {
+            this.SetHighlightColor(event.target.value);
+        });
+
+        let clearButton = AddDiv(this.panel, 'ov_highlight_clear_button');
+        clearButton.innerHTML = '<button>Clear Highlight</button>';
+        clearButton.addEventListener('click', () => {
+            this.ClearHighlight();
+        });
+
+        this.Resize();
+    }
+
+    Resize() {
+        if (!this.isActive) {
+            return;
+        }
+        let canvas = this.viewer.GetCanvas();
+        let canvasRect = canvas.getBoundingClientRect();
+        let panelRect = this.panel.getBoundingClientRect();
+        let canvasWidth = canvasRect.right - canvasRect.left;
+        let panelWidth = panelRect.right - panelRect.left;
+        this.panel.style.left = (canvasRect.left + (canvasWidth - panelWidth) / 2) + 'px';
+        this.panel.style.top = (canvasRect.top + 10) + 'px';
+    }
+
+    ClearHighlight() {
+        this.highlightMeshes.forEach((mesh) => {
+            this.viewer.RemoveExtraObject(mesh);
+        });
+        this.highlightMeshes = [];
+        this.viewer.Render();
+    }
+
+    SetHighlightColor(color) {
+        this.highlightColor.set(color);
+    }
+}

--- a/source/website/website.js
+++ b/source/website/website.js
@@ -195,10 +195,10 @@ export class Website
         this.cameraSettings = new CameraSettings ();
         this.viewer = new Viewer ();
         this.measureTool = new MeasureTool (this.viewer, this.settings);
-        this.highlightTool = new HighlightTool(this.viewer, this.settings);
         this.hashHandler = new HashHandler ();
         this.toolbar = new Toolbar (this.parameters.toolbarDiv);
         this.navigator = new Navigator (this.parameters.navigatorDiv);
+        this.highlightTool = new HighlightTool(this.viewer, this.settings);
         this.sidebar = new Sidebar (this.parameters.sidebarDiv, this.settings);
         this.modelLoaderUI = new ThreeModelLoaderUI ();
         this.themeHandler = new ThemeHandler ();


### PR DESCRIPTION
Introduces a new feature allowing users to highlight regions of a 3D mesh by clicking and dragging the mouse or using touch interactions on mobile devices. The highlighted areas are rendered with a semi-transparent red overlay.

Key Changes:

- Implemented HighlightTool class to manage highlighting functionality.
- Added touch event listeners for mobile support.
- One Touch to Highlight & Two Finger Touch for unhighlight.
- Mouse Left to Highlight & Mouse Right to Unhighlight