### PR TITLE
chore: upgraded dependencies and resolved packages vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,35 +1,37 @@
 {
 	"name": "online-3d-viewer",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "online-3d-viewer",
-			"version": "0.13.0",
+			"version": "0.14.0",
 			"license": "MIT",
 			"dependencies": {
-				"@simonwep/pickr": "1.9.0",
+				"@simonwep/pickr": "1.9.1",
 				"fflate": "0.8.2",
-				"occt-import-js": "0.0.21",
-				"three": "0.163.0",
-				"web-ifc": "0.0.44"
+				"three": "0.168.0"
 			},
 			"devDependencies": {
-				"@types/node": "^20.1.0",
-				"draco3d": "1.5.7",
-				"esbuild": "^0.20.0",
-				"eslint": "^8.29.0",
-				"eslint-plugin-unused-imports": "^3.0.0",
-				"fantasticon": "^1.2.2",
+				"@types/node": "^20.16.5",
+				"esbuild": "^0.23.1",
+				"eslint": "^8.57.0",
+				"eslint-plugin-unused-imports": "^3.2.0",
+				"fantasticon": "^3.0.0",
 				"http-server": "^14.0.0",
-				"jsdoc": "^4.0.0",
-				"mocha": "^10.2.0",
-				"oslllo-svg-fixer": "^3.0.0",
-				"rollup": "^4.0.2",
+				"jsdoc": "^4.0.3",
+				"mocha": "^10.7.3",
+				"oslllo-svg-fixer": "^5.0.0",
+				"rollup": "^4.21.2",
 				"run-python3": "^0.0.5",
-				"svgo": "^3.0.2",
-				"typescript": "^5.0.4"
+				"svgo": "^3.3.2",
+				"typescript": "^5.6.2",
+				"web-ifc": "0.0.57"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=6.0.0"
 			}
 		},
 		"node_modules/@babel/parser": {
@@ -44,390 +46,412 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/runtime": {
-			"version": "7.24.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-			"integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"dev": true
-		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-			"integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+			"integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"aix"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-			"integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+			"integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-			"integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+			"integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-			"integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+			"integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-			"integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+			"integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-			"integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+			"integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-			"integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+			"integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-			"integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+			"integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-			"integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+			"integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-			"integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+			"integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-			"integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+			"integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-			"integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+			"integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
 			"cpu": [
 				"loong64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-			"integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+			"integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
 			"cpu": [
 				"mips64el"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-			"integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+			"integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-			"integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+			"integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-			"integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+			"integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-			"integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+			"integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-			"integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+			"integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"netbsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-			"integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+			"integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
 			"cpu": [
-				"x64"
+				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openbsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-			"integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+			"integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+			"integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"sunos"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-			"integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+			"integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-			"integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+			"integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-			"integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+			"integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -490,7 +514,8 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
 			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.14",
@@ -525,14 +550,117 @@
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"dev": true
 		},
-		"node_modules/@jimp/bmp": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.13.tgz",
-			"integrity": "sha512-9edAxu7N2FX7vzkdl5Jo1BbACfycUtBQX+XBMcHA2bk62P8R0otgkHg798frgAk/WxQIzwxqOH6wMiCwrlAzdQ==",
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13",
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@jimp/bmp": {
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.22.12.tgz",
+			"integrity": "sha512-aeI64HD0npropd+AR76MCcvvRaa+Qck6loCOS03CkkxGHN5/r336qTM5HPUdHKMDOGzqknuVPA8+kK1t03z12g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jimp/utils": "^0.22.12",
 				"bmp-js": "^0.1.0"
 			},
 			"peerDependencies": {
@@ -540,55 +668,41 @@
 			}
 		},
 		"node_modules/@jimp/core": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.13.tgz",
-			"integrity": "sha512-qXpA1tzTnlkTku9yqtuRtS/wVntvE6f3m3GNxdTdtmc+O+Wcg9Xo2ABPMh7Nc0AHbMKzwvwgB2JnjZmlmJEObg==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.22.12.tgz",
+			"integrity": "sha512-l0RR0dOPyzMKfjUW1uebzueFEDtCOj9fN6pyTYWWOM/VS4BciXQ1VVrJs8pO3kycGYZxncRKhCoygbNr8eEZQA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13",
+				"@jimp/utils": "^0.22.12",
 				"any-base": "^1.1.0",
 				"buffer": "^5.2.0",
 				"exif-parser": "^0.1.12",
 				"file-type": "^16.5.4",
-				"load-bmfont": "^1.3.1",
-				"mkdirp": "^0.5.1",
-				"phin": "^2.9.1",
+				"isomorphic-fetch": "^3.0.0",
 				"pixelmatch": "^4.0.2",
-				"tinycolor2": "^1.4.1"
-			}
-		},
-		"node_modules/@jimp/core/node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
+				"tinycolor2": "^1.6.0"
 			}
 		},
 		"node_modules/@jimp/custom": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.13.tgz",
-			"integrity": "sha512-LTATglVUPGkPf15zX1wTMlZ0+AU7cGEGF6ekVF1crA8eHUWsGjrYTB+Ht4E3HTrCok8weQG+K01rJndCp/l4XA==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
+			"integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/core": "^0.16.13"
+				"@jimp/core": "^0.22.12"
 			}
 		},
 		"node_modules/@jimp/gif": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.13.tgz",
-			"integrity": "sha512-yFAMZGv3o+YcjXilMWWwS/bv1iSqykFahFMSO169uVMtfQVfa90kt4/kDwrXNR6Q9i6VHpFiGZMlF2UnHClBvg==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.22.12.tgz",
+			"integrity": "sha512-y6BFTJgch9mbor2H234VSjd9iwAhaNf/t3US5qpYIs0TSbAvM02Fbc28IaDETj9+4YB4676sz4RcN/zwhfu1pg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13",
-				"gifwrap": "^0.9.2",
+				"@jimp/utils": "^0.22.12",
+				"gifwrap": "^0.10.1",
 				"omggif": "^1.0.9"
 			},
 			"peerDependencies": {
@@ -596,80 +710,80 @@
 			}
 		},
 		"node_modules/@jimp/jpeg": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.13.tgz",
-			"integrity": "sha512-BJHlDxzTlCqP2ThqP8J0eDrbBfod7npWCbJAcfkKqdQuFk0zBPaZ6KKaQKyKxmWJ87Z6ohANZoMKEbtvrwz1AA==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.22.12.tgz",
+			"integrity": "sha512-Rq26XC/uQWaQKyb/5lksCTCxXhtY01NJeBN+dQv5yNYedN0i7iYu+fXEoRsfaJ8xZzjoANH8sns7rVP4GE7d/Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13",
-				"jpeg-js": "^0.4.2"
+				"@jimp/utils": "^0.22.12",
+				"jpeg-js": "^0.4.4"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-blit": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.13.tgz",
-			"integrity": "sha512-8Z1k96ZFxlhK2bgrY1JNWNwvaBeI/bciLM0yDOni2+aZwfIIiC7Y6PeWHTAvjHNjphz+XCt01WQmOYWCn0ML6g==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
+			"integrity": "sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-blur": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.13.tgz",
-			"integrity": "sha512-PvLrfa8vkej3qinlebyhLpksJgCF5aiysDMSVhOZqwH5nQLLtDE9WYbnsofGw4r0VVpyw3H/ANCIzYTyCtP9Cg==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.12.tgz",
+			"integrity": "sha512-S0vJADTuh1Q9F+cXAwFPlrKWzDj2F9t/9JAbUvaaDuivpyWuImEKXVz5PUZw2NbpuSHjwssbTpOZ8F13iJX4uw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-circle": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.13.tgz",
-			"integrity": "sha512-RNave7EFgZrb5V5EpdvJGAEHMnDAJuwv05hKscNfIYxf0kR3KhViBTDy+MoTnMlIvaKFULfwIgaZWzyhuINMzA==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.22.12.tgz",
+			"integrity": "sha512-SWVXx1yiuj5jZtMijqUfvVOJBwOifFn0918ou4ftoHgegc5aHWW5dZbYPjvC9fLpvz7oSlptNl2Sxr1zwofjTg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-color": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.13.tgz",
-			"integrity": "sha512-xW+9BtEvoIkkH/Wde9ql4nAFbYLkVINhpgAE7VcBUsuuB34WUbcBl/taOuUYQrPEFQJ4jfXiAJZ2H/rvKjCVnQ==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
+			"integrity": "sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13",
-				"tinycolor2": "^1.4.1"
+				"@jimp/utils": "^0.22.12",
+				"tinycolor2": "^1.6.0"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-contain": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.13.tgz",
-			"integrity": "sha512-QayTXw4tXMwU6q6acNTQrTTFTXpNRBe+MgTGMDU0lk+23PjlFCO/9sacflelG8lsp7vNHhAxFeHptDMAksEYzg==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.22.12.tgz",
+			"integrity": "sha512-Eo3DmfixJw3N79lWk8q/0SDYbqmKt1xSTJ69yy8XLYQj9svoBbyRpSnHR+n9hOw5pKXytHwUW6nU4u1wegHNoQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5",
@@ -679,13 +793,13 @@
 			}
 		},
 		"node_modules/@jimp/plugin-cover": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.13.tgz",
-			"integrity": "sha512-BSsP71GTNaqWRcvkbWuIVH+zK7b3TSNebbhDkFK0fVaUTzHuKMS/mgY4hDZIEVt7Rf5FjadAYtsujHN9w0iSYA==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.22.12.tgz",
+			"integrity": "sha512-z0w/1xH/v/knZkpTNx+E8a7fnasQ2wHG5ze6y5oL2dhH1UufNua8gLQXlv8/W56+4nJ1brhSd233HBJCo01BXA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5",
@@ -695,65 +809,65 @@
 			}
 		},
 		"node_modules/@jimp/plugin-crop": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.13.tgz",
-			"integrity": "sha512-WEl2tPVYwzYL8OKme6Go2xqiWgKsgxlMwyHabdAU4tXaRwOCnOI7v4021gCcBb9zn/oWwguHuKHmK30Fw2Z/PA==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
+			"integrity": "sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-displace": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.13.tgz",
-			"integrity": "sha512-qt9WKq8vWrcjySa9DyQ0x/RBMHQeiVjdVSY1SJsMjssPUf0pS74qorcuAkGi89biN3YoGUgPkpqECnAWnYwgGA==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.22.12.tgz",
+			"integrity": "sha512-qpRM8JRicxfK6aPPqKZA6+GzBwUIitiHaZw0QrJ64Ygd3+AsTc7BXr+37k2x7QcyCvmKXY4haUrSIsBug4S3CA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-dither": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.13.tgz",
-			"integrity": "sha512-5/N3yJggbWQTlGZHQYJPmQXEwR52qaXjEzkp1yRBbtdaekXE3BG/suo0fqeoV/csf8ooI78sJzYmIrxNoWVtgQ==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.22.12.tgz",
+			"integrity": "sha512-jYgGdSdSKl1UUEanX8A85v4+QUm+PE8vHFwlamaKk89s+PXQe7eVE3eNeSZX4inCq63EHL7cX580dMqkoC3ZLw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-fisheye": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.13.tgz",
-			"integrity": "sha512-2rZmTdFbT/cF9lEZIkXCYO0TsT114Q27AX5IAo0Sju6jVQbvIk1dFUTnwLDadTo8wkJlFzGqMQ24Cs8cHWOliA==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.22.12.tgz",
+			"integrity": "sha512-LGuUTsFg+fOp6KBKrmLkX4LfyCy8IIsROwoUvsUPKzutSqMJnsm3JGDW2eOmWIS/jJpPaeaishjlxvczjgII+Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-flip": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.13.tgz",
-			"integrity": "sha512-EmcgAA74FTc5u7Z+hUO/sRjWwfPPLuOQP5O64x5g4j0T12Bd29IgsYZxoutZo/rb3579+JNa/3wsSEmyVv1EpA==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.22.12.tgz",
+			"integrity": "sha512-m251Rop7GN8W0Yo/rF9LWk6kNclngyjIJs/VXHToGQ6EGveOSTSQaX2Isi9f9lCDLxt+inBIb7nlaLLxnvHX8Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5",
@@ -761,66 +875,66 @@
 			}
 		},
 		"node_modules/@jimp/plugin-gaussian": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.13.tgz",
-			"integrity": "sha512-A1XKfGQD0iDdIiKqFYi8nZMv4dDVYdxbrmgR7y/CzUHhSYdcmoljLIIsZZM3Iks/Wa353W3vtvkWLuDbQbch1w==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.22.12.tgz",
+			"integrity": "sha512-sBfbzoOmJ6FczfG2PquiK84NtVGeScw97JsCC3rpQv1PHVWyW+uqWFF53+n3c8Y0P2HWlUjflEla2h/vWShvhg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-invert": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.13.tgz",
-			"integrity": "sha512-xFMrIn7czEZbdbMzZWuaZFnlLGJDVJ82y5vlsKsXRTG2kcxRsMPXvZRWHV57nSs1YFsNqXSbrC8B98n0E32njQ==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.22.12.tgz",
+			"integrity": "sha512-N+6rwxdB+7OCR6PYijaA/iizXXodpxOGvT/smd/lxeXsZ/empHmFFFJ/FaXcYh19Tm04dGDaXcNF/dN5nm6+xQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-mask": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.13.tgz",
-			"integrity": "sha512-wLRYKVBXql2GAYgt6FkTnCfE+q5NomM7Dlh0oIPGAoMBWDyTx0eYutRK6PlUrRK2yMHuroAJCglICTbxqGzowQ==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.22.12.tgz",
+			"integrity": "sha512-4AWZg+DomtpUA099jRV8IEZUfn1wLv6+nem4NRJC7L/82vxzLCgXKTxvNvBcNmJjT9yS1LAAmiJGdWKXG63/NA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-normalize": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.13.tgz",
-			"integrity": "sha512-3tfad0n9soRna4IfW9NzQdQ2Z3ijkmo21DREHbE6CGcMIxOSvfRdSvf1qQPApxjTSo8LTU4MCi/fidx/NZ0GqQ==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.22.12.tgz",
+			"integrity": "sha512-0So0rexQivnWgnhacX4cfkM2223YdExnJTTy6d06WbkfZk5alHUx8MM3yEzwoCN0ErO7oyqEWRnEkGC+As1FtA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-print": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.13.tgz",
-			"integrity": "sha512-0m6i3p01PGRkGAK9r53hDYrkyMq+tlhLOIbsSTmZyh6HLshUKlTB7eXskF5OpVd5ZUHoltlNc6R+ggvKIzxRFw==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.22.12.tgz",
+			"integrity": "sha512-c7TnhHlxm87DJeSnwr/XOLjJU/whoiKYY7r21SbuJ5nuH+7a78EW1teOaj5gEr2wYEd7QtkFqGlmyGXY/YclyQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13",
-				"load-bmfont": "^1.4.0"
+				"@jimp/utils": "^0.22.12",
+				"load-bmfont": "^1.4.1"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5",
@@ -828,26 +942,26 @@
 			}
 		},
 		"node_modules/@jimp/plugin-resize": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.13.tgz",
-			"integrity": "sha512-qoqtN8LDknm3fJm9nuPygJv30O3vGhSBD2TxrsCnhtOsxKAqVPJtFVdGd/qVuZ8nqQANQmTlfqTiK9mVWQ7MiQ==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
+			"integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/plugin-rotate": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.13.tgz",
-			"integrity": "sha512-Ev+Jjmj1nHYw897z9C3R9dYsPv7S2/nxdgfFb/h8hOwK0Ovd1k/+yYS46A0uj/JCKK0pQk8wOslYBkPwdnLorw==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
+			"integrity": "sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5",
@@ -857,13 +971,13 @@
 			}
 		},
 		"node_modules/@jimp/plugin-scale": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.13.tgz",
-			"integrity": "sha512-05POQaEJVucjTiSGMoH68ZiELc7QqpIpuQlZ2JBbhCV+WCbPFUBcGSmE7w4Jd0E2GvCho/NoMODLwgcVGQA97A==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
+			"integrity": "sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5",
@@ -871,13 +985,13 @@
 			}
 		},
 		"node_modules/@jimp/plugin-shadow": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.13.tgz",
-			"integrity": "sha512-nmu5VSZ9hsB1JchTKhnnCY+paRBnwzSyK5fhkhtQHHoFD5ArBQ/5wU8y6tCr7k/GQhhGq1OrixsECeMjPoc8Zw==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.22.12.tgz",
+			"integrity": "sha512-FX8mTJuCt7/3zXVoeD/qHlm4YH2bVqBuWQHXSuBK054e7wFRnRnbSLPUqAwSeYP3lWqpuQzJtgiiBxV3+WWwTg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5",
@@ -886,13 +1000,13 @@
 			}
 		},
 		"node_modules/@jimp/plugin-threshold": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.13.tgz",
-			"integrity": "sha512-+3zArBH0OE3Rhjm4HyAokMsZlIq5gpQec33CncyoSwxtRBM2WAhUVmCUKuBo+Lr/2/4ISoY4BWpHKhMLDix6cA==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.22.12.tgz",
+			"integrity": "sha512-4x5GrQr1a/9L0paBC/MZZJjjgjxLYrqSmWd+e+QfAEPvmRxdRoQ5uKEuNgXnm9/weHQBTnQBQsOY2iFja+XGAw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13"
+				"@jimp/utils": "^0.22.12"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5",
@@ -901,33 +1015,33 @@
 			}
 		},
 		"node_modules/@jimp/plugins": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.13.tgz",
-			"integrity": "sha512-CJLdqODEhEVs4MgWCxpWL5l95sCBlkuSLz65cxEm56X5akIsn4LOlwnKoSEZioYcZUBvHhCheH67AyPTudfnQQ==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.22.12.tgz",
+			"integrity": "sha512-yBJ8vQrDkBbTgQZLty9k4+KtUQdRjsIDJSPjuI21YdVeqZxYywifHl4/XWILoTZsjTUASQcGoH0TuC0N7xm3ww==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/plugin-blit": "^0.16.13",
-				"@jimp/plugin-blur": "^0.16.13",
-				"@jimp/plugin-circle": "^0.16.13",
-				"@jimp/plugin-color": "^0.16.13",
-				"@jimp/plugin-contain": "^0.16.13",
-				"@jimp/plugin-cover": "^0.16.13",
-				"@jimp/plugin-crop": "^0.16.13",
-				"@jimp/plugin-displace": "^0.16.13",
-				"@jimp/plugin-dither": "^0.16.13",
-				"@jimp/plugin-fisheye": "^0.16.13",
-				"@jimp/plugin-flip": "^0.16.13",
-				"@jimp/plugin-gaussian": "^0.16.13",
-				"@jimp/plugin-invert": "^0.16.13",
-				"@jimp/plugin-mask": "^0.16.13",
-				"@jimp/plugin-normalize": "^0.16.13",
-				"@jimp/plugin-print": "^0.16.13",
-				"@jimp/plugin-resize": "^0.16.13",
-				"@jimp/plugin-rotate": "^0.16.13",
-				"@jimp/plugin-scale": "^0.16.13",
-				"@jimp/plugin-shadow": "^0.16.13",
-				"@jimp/plugin-threshold": "^0.16.13",
+				"@jimp/plugin-blit": "^0.22.12",
+				"@jimp/plugin-blur": "^0.22.12",
+				"@jimp/plugin-circle": "^0.22.12",
+				"@jimp/plugin-color": "^0.22.12",
+				"@jimp/plugin-contain": "^0.22.12",
+				"@jimp/plugin-cover": "^0.22.12",
+				"@jimp/plugin-crop": "^0.22.12",
+				"@jimp/plugin-displace": "^0.22.12",
+				"@jimp/plugin-dither": "^0.22.12",
+				"@jimp/plugin-fisheye": "^0.22.12",
+				"@jimp/plugin-flip": "^0.22.12",
+				"@jimp/plugin-gaussian": "^0.22.12",
+				"@jimp/plugin-invert": "^0.22.12",
+				"@jimp/plugin-mask": "^0.22.12",
+				"@jimp/plugin-normalize": "^0.22.12",
+				"@jimp/plugin-print": "^0.22.12",
+				"@jimp/plugin-resize": "^0.22.12",
+				"@jimp/plugin-rotate": "^0.22.12",
+				"@jimp/plugin-scale": "^0.22.12",
+				"@jimp/plugin-shadow": "^0.22.12",
+				"@jimp/plugin-threshold": "^0.22.12",
 				"timm": "^1.6.1"
 			},
 			"peerDependencies": {
@@ -935,44 +1049,44 @@
 			}
 		},
 		"node_modules/@jimp/png": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.13.tgz",
-			"integrity": "sha512-8cGqINvbWJf1G0Her9zbq9I80roEX0A+U45xFby3tDWfzn+Zz8XKDF1Nv9VUwVx0N3zpcG1RPs9hfheG4Cq2kg==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.22.12.tgz",
+			"integrity": "sha512-Mrp6dr3UTn+aLK8ty/dSKELz+Otdz1v4aAXzV5q53UDD2rbB5joKVJ/ChY310B+eRzNxIovbUF1KVrUsYdE8Hg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/utils": "^0.16.13",
-				"pngjs": "^3.3.3"
+				"@jimp/utils": "^0.22.12",
+				"pngjs": "^6.0.0"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/tiff": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.13.tgz",
-			"integrity": "sha512-oJY8d9u95SwW00VPHuCNxPap6Q1+E/xM5QThb9Hu+P6EGuu6lIeLaNBMmFZyblwFbwrH+WBOZlvIzDhi4Dm/6Q==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.22.12.tgz",
+			"integrity": "sha512-E1LtMh4RyJsoCAfAkBRVSYyZDTtLq9p9LUiiYP0vPtXyxX4BiYBUYihTLSBlCQg5nF2e4OpQg7SPrLdJ66u7jg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"utif": "^2.0.1"
+				"utif2": "^4.0.1"
 			},
 			"peerDependencies": {
 				"@jimp/custom": ">=0.3.5"
 			}
 		},
 		"node_modules/@jimp/types": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.13.tgz",
-			"integrity": "sha512-mC0yVNUobFDjoYLg4hoUwzMKgNlxynzwt3cDXzumGvRJ7Kb8qQGOWJQjQFo5OxmGExqzPphkirdbBF88RVLBCg==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.22.12.tgz",
+			"integrity": "sha512-wwKYzRdElE1MBXFREvCto5s699izFHNVvALUv79GXNbsOVqlwlOxlWJ8DuyOGIXoLP4JW/m30YyuTtfUJgMRMA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/bmp": "^0.16.13",
-				"@jimp/gif": "^0.16.13",
-				"@jimp/jpeg": "^0.16.13",
-				"@jimp/png": "^0.16.13",
-				"@jimp/tiff": "^0.16.13",
+				"@jimp/bmp": "^0.22.12",
+				"@jimp/gif": "^0.22.12",
+				"@jimp/jpeg": "^0.22.12",
+				"@jimp/png": "^0.22.12",
+				"@jimp/tiff": "^0.22.12",
 				"timm": "^1.6.1"
 			},
 			"peerDependencies": {
@@ -980,12 +1094,12 @@
 			}
 		},
 		"node_modules/@jimp/utils": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.13.tgz",
-			"integrity": "sha512-VyCpkZzFTHXtKgVO35iKN0sYR10psGpV6SkcSeV4oF7eSYlR8Bl6aQLCzVeFjvESF7mxTmIiI3/XrMobVrtxDA==",
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.22.12.tgz",
+			"integrity": "sha512-yJ5cWUknGnilBq97ZXOyOS0HhsHOyAyjHwYfHxGbSyMTohgQI6sVyE8KPgDwH8HHW/nMKXk8TrSwAE71zt716Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
 				"regenerator-runtime": "^0.13.3"
 			}
 		},
@@ -1041,6 +1155,7 @@
 			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
 			"integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@gar/promisify": "^1.1.3",
 				"semver": "^7.3.5"
@@ -1055,6 +1170,7 @@
 			"integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
 			"deprecated": "This functionality has been moved to @npmcli/fs",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"mkdirp": "^1.0.4",
 				"rimraf": "^3.0.2"
@@ -1063,11 +1179,23 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@resvg/resvg-js": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
 			"integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
 			"dev": true,
+			"license": "MPL-2.0",
 			"engines": {
 				"node": ">= 10"
 			},
@@ -1094,6 +1222,7 @@
 				"arm"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"android"
@@ -1110,6 +1239,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"android"
@@ -1126,6 +1256,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1142,6 +1273,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1158,6 +1290,7 @@
 				"arm"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1174,6 +1307,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1190,6 +1324,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1206,6 +1341,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1222,6 +1358,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1238,6 +1375,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1254,6 +1392,7 @@
 				"ia32"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1270,6 +1409,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1279,233 +1419,252 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.16.4.tgz",
-			"integrity": "sha512-GkhjAaQ8oUTOKE4g4gsZ0u8K/IHU1+2WQSgS1TwTcYvL+sjbaQjNHFXbOJ6kgqGHIO1DfUhI/Sphi9GkRT9K+Q==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.2.tgz",
+			"integrity": "sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.16.4.tgz",
-			"integrity": "sha512-Bvm6D+NPbGMQOcxvS1zUl8H7DWlywSXsphAeOnVeiZLQ+0J6Is8T7SrjGTH29KtYkiY9vld8ZnpV3G2EPbom+w==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.2.tgz",
+			"integrity": "sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.16.4.tgz",
-			"integrity": "sha512-i5d64MlnYBO9EkCOGe5vPR/EeDwjnKOGGdd7zKFhU5y8haKhQZTN2DgVtpODDMxUr4t2K90wTUJg7ilgND6bXw==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.2.tgz",
+			"integrity": "sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.16.4.tgz",
-			"integrity": "sha512-WZupV1+CdUYehaZqjaFTClJI72fjJEgTXdf4NbW69I9XyvdmztUExBtcI2yIIU6hJtYvtwS6pkTkHJz+k08mAQ==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.2.tgz",
+			"integrity": "sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.16.4.tgz",
-			"integrity": "sha512-ADm/xt86JUnmAfA9mBqFcRp//RVRt1ohGOYF6yL+IFCYqOBNwy5lbEK05xTsEoJq+/tJzg8ICUtS82WinJRuIw==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.2.tgz",
+			"integrity": "sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.16.4.tgz",
-			"integrity": "sha512-tJfJaXPiFAG+Jn3cutp7mCs1ePltuAgRqdDZrzb1aeE3TktWWJ+g7xK9SNlaSUFw6IU4QgOxAY4rA+wZUT5Wfg==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.2.tgz",
+			"integrity": "sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.16.4.tgz",
-			"integrity": "sha512-7dy1BzQkgYlUTapDTvK997cgi0Orh5Iu7JlZVBy1MBURk7/HSbHkzRnXZa19ozy+wwD8/SlpJnOOckuNZtJR9w==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.2.tgz",
+			"integrity": "sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.16.4.tgz",
-			"integrity": "sha512-zsFwdUw5XLD1gQe0aoU2HVceI6NEW7q7m05wA46eUAyrkeNYExObfRFQcvA6zw8lfRc5BHtan3tBpo+kqEOxmg==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.2.tgz",
+			"integrity": "sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.16.4.tgz",
-			"integrity": "sha512-p8C3NnxXooRdNrdv6dBmRTddEapfESEUflpICDNKXpHvTjRRq1J82CbU5G3XfebIZyI3B0s074JHMWD36qOW6w==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.2.tgz",
+			"integrity": "sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.16.4.tgz",
-			"integrity": "sha512-Lh/8ckoar4s4Id2foY7jNgitTOUQczwMWNYi+Mjt0eQ9LKhr6sK477REqQkmy8YHY3Ca3A2JJVdXnfb3Rrwkng==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.2.tgz",
+			"integrity": "sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.16.4.tgz",
-			"integrity": "sha512-1xwwn9ZCQYuqGmulGsTZoKrrn0z2fAur2ujE60QgyDpHmBbXbxLaQiEvzJWDrscRq43c8DnuHx3QorhMTZgisQ==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.2.tgz",
+			"integrity": "sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.16.4.tgz",
-			"integrity": "sha512-LuOGGKAJ7dfRtxVnO1i3qWc6N9sh0Em/8aZ3CezixSTM+E9Oq3OvTsvC4sm6wWjzpsIlOCnZjdluINKESflJLA==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz",
+			"integrity": "sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.16.4.tgz",
-			"integrity": "sha512-ch86i7KkJKkLybDP2AtySFTRi5fM3KXp0PnHocHuJMdZwu7BuyIKi35BE9guMlmTpwwBTB3ljHj9IQXnTCD0vA==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.2.tgz",
+			"integrity": "sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.16.4.tgz",
-			"integrity": "sha512-Ma4PwyLfOWZWayfEsNQzTDBVW8PZ6TUUN1uFTBQbF2Chv/+sjenE86lpiEwj2FiviSmSZ4Ap4MaAfl1ciF4aSA==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.2.tgz",
+			"integrity": "sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.16.4.tgz",
-			"integrity": "sha512-9m/ZDrQsdo/c06uOlP3W9G2ENRVzgzbSXmXHT4hwVaDQhYcRpi9bgBT0FTG9OhESxwK0WjQxYOSfv40cU+T69w==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.2.tgz",
+			"integrity": "sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.16.4.tgz",
-			"integrity": "sha512-YunpoOAyGLDseanENHmbFvQSfVL5BxW3k7hhy0eN4rb3gS/ct75dVD0EXOWIqFT/nE8XYW6LP6vz6ctKRi0k9A==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.2.tgz",
+			"integrity": "sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			]
 		},
 		"node_modules/@simonwep/pickr": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@simonwep/pickr/-/pickr-1.9.0.tgz",
-			"integrity": "sha512-oEYvv15PyfZzjoAzvXYt3UyNGwzsrpFxLaZKzkOSd0WYBVwLd19iJerePDONxC1iF6+DpcswPdLIM2KzCJuYFg==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@simonwep/pickr/-/pickr-1.9.1.tgz",
+			"integrity": "sha512-fR3qmfAcPf/HSFS7GEnTmZLM3+xERv1+jyMBbzT63ilRRM8veYjI7ELvkHHKk0/du3lHp7uh/FqatjM3646X1g==",
+			"license": "MIT",
 			"dependencies": {
-				"core-js": "3.32.2",
-				"nanopop": "2.3.0"
+				"core-js": "3.37.0",
+				"nanopop": "2.4.2"
 			}
 		},
 		"node_modules/@tokenizer/token": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
 			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
 			}
@@ -1526,34 +1685,38 @@
 			"dev": true
 		},
 		"node_modules/@types/linkify-it": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
-			"integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
-			"dev": true
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/markdown-it": {
-			"version": "12.2.3",
-			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-			"integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+			"version": "14.1.2",
+			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+			"integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@types/linkify-it": "*",
-				"@types/mdurl": "*"
+				"@types/linkify-it": "^5",
+				"@types/mdurl": "^2"
 			}
 		},
 		"node_modules/@types/mdurl": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
-			"integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
-			"dev": true
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.12.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-			"integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+			"version": "20.16.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.5.tgz",
+			"integrity": "sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~6.19.2"
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
@@ -1575,7 +1738,8 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/acorn": {
 			"version": "8.11.3",
@@ -1603,6 +1767,7 @@
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
 			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"debug": "4"
 			},
@@ -1615,6 +1780,7 @@
 			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
 			"integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"humanize-ms": "^1.2.1"
 			},
@@ -1627,6 +1793,7 @@
 			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
 			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"clean-stack": "^2.0.0",
 				"indent-string": "^4.0.0"
@@ -1652,10 +1819,11 @@
 			}
 		},
 		"node_modules/ansi-colors": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -1688,7 +1856,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
 			"integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
@@ -1707,13 +1876,16 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
 			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/are-we-there-yet": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
 			"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+			"deprecated": "This package is no longer supported.",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^3.6.0"
@@ -1761,7 +1933,8 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "MIT"
 		},
 		"node_modules/basic-auth": {
 			"version": "2.0.1",
@@ -1792,6 +1965,7 @@
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -1806,7 +1980,8 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
 			"integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
@@ -1825,12 +2000,13 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -1861,6 +2037,7 @@
 					"url": "https://feross.org/support"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
@@ -1871,6 +2048,7 @@
 			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
 			"integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -1880,6 +2058,7 @@
 			"resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-3.0.0.tgz",
 			"integrity": "sha512-Qg0ggJUWJq90vtg4lDsGN9CDWvzBMQxhiEkSOD/sJfYt6BLect3eV1/S6K7SCSKJ34n60rf6U5eUPmQENVE4UA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"readable-stream": "^3.4.0"
 			},
@@ -1892,6 +2071,7 @@
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
 			"integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@npmcli/fs": "^2.1.0",
 				"@npmcli/move-file": "^2.0.0",
@@ -1921,6 +2101,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -1929,7 +2110,9 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
 			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1949,6 +2132,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
 			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -1984,16 +2168,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/camel-case": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-			"dev": true,
-			"dependencies": {
-				"pascal-case": "^3.1.2",
-				"tslib": "^2.0.3"
-			}
-		},
 		"node_modules/camelcase": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -2006,15 +2180,14 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/capital-case": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+		"node_modules/case": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
+			"integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
 			"dev": true,
-			"dependencies": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
+			"license": "(MIT OR GPL-3.0-or-later)",
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/catharsis": {
@@ -2027,6 +2200,16 @@
 			},
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/centra": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
+			"integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.6"
 			}
 		},
 		"node_modules/chalk": {
@@ -2043,26 +2226,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/change-case": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-			"dev": true,
-			"dependencies": {
-				"camel-case": "^4.1.2",
-				"capital-case": "^1.0.4",
-				"constant-case": "^3.0.4",
-				"dot-case": "^3.0.4",
-				"header-case": "^2.0.4",
-				"no-case": "^3.0.4",
-				"param-case": "^3.0.4",
-				"pascal-case": "^3.1.2",
-				"path-case": "^3.0.4",
-				"sentence-case": "^3.0.4",
-				"snake-case": "^3.0.4",
-				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/child_process": {
@@ -2115,6 +2278,7 @@
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
 			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}
@@ -2124,6 +2288,7 @@
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
 			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -2190,6 +2355,7 @@
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
 			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"color-support": "bin.js"
 			}
@@ -2213,34 +2379,19 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-			"dev": true
-		},
-		"node_modules/constant-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
 			"dev": true,
-			"dependencies": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case": "^2.0.2"
-			}
+			"license": "ISC"
 		},
 		"node_modules/core-js": {
-			"version": "3.32.2",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
-			"integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==",
+			"version": "3.37.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
+			"integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
 			"hasInstallScript": true,
+			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
 			}
-		},
-		"node_modules/core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true
 		},
 		"node_modules/corser": {
 			"version": "2.0.1",
@@ -2359,12 +2510,13 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -2414,13 +2566,15 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/diff": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -2449,18 +2603,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/dom-serializer/node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/dom-walk": {
@@ -2500,7 +2642,8 @@
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
 			"integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/domutils": {
 			"version": "3.1.0",
@@ -2516,21 +2659,12 @@
 				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
-		"node_modules/dot-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"dev": true,
-			"dependencies": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/draco3d": {
-			"version": "1.5.7",
-			"resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
-			"integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
-			"dev": true
+			"license": "MIT"
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -2549,10 +2683,14 @@
 			}
 		},
 		"node_modules/entities": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-			"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
 			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
@@ -2562,6 +2700,7 @@
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
 			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -2570,7 +2709,8 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
 			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es-define-property": {
 			"version": "1.0.0",
@@ -2646,41 +2786,43 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-			"integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+			"integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.20.2",
-				"@esbuild/android-arm": "0.20.2",
-				"@esbuild/android-arm64": "0.20.2",
-				"@esbuild/android-x64": "0.20.2",
-				"@esbuild/darwin-arm64": "0.20.2",
-				"@esbuild/darwin-x64": "0.20.2",
-				"@esbuild/freebsd-arm64": "0.20.2",
-				"@esbuild/freebsd-x64": "0.20.2",
-				"@esbuild/linux-arm": "0.20.2",
-				"@esbuild/linux-arm64": "0.20.2",
-				"@esbuild/linux-ia32": "0.20.2",
-				"@esbuild/linux-loong64": "0.20.2",
-				"@esbuild/linux-mips64el": "0.20.2",
-				"@esbuild/linux-ppc64": "0.20.2",
-				"@esbuild/linux-riscv64": "0.20.2",
-				"@esbuild/linux-s390x": "0.20.2",
-				"@esbuild/linux-x64": "0.20.2",
-				"@esbuild/netbsd-x64": "0.20.2",
-				"@esbuild/openbsd-x64": "0.20.2",
-				"@esbuild/sunos-x64": "0.20.2",
-				"@esbuild/win32-arm64": "0.20.2",
-				"@esbuild/win32-ia32": "0.20.2",
-				"@esbuild/win32-x64": "0.20.2"
+				"@esbuild/aix-ppc64": "0.23.1",
+				"@esbuild/android-arm": "0.23.1",
+				"@esbuild/android-arm64": "0.23.1",
+				"@esbuild/android-x64": "0.23.1",
+				"@esbuild/darwin-arm64": "0.23.1",
+				"@esbuild/darwin-x64": "0.23.1",
+				"@esbuild/freebsd-arm64": "0.23.1",
+				"@esbuild/freebsd-x64": "0.23.1",
+				"@esbuild/linux-arm": "0.23.1",
+				"@esbuild/linux-arm64": "0.23.1",
+				"@esbuild/linux-ia32": "0.23.1",
+				"@esbuild/linux-loong64": "0.23.1",
+				"@esbuild/linux-mips64el": "0.23.1",
+				"@esbuild/linux-ppc64": "0.23.1",
+				"@esbuild/linux-riscv64": "0.23.1",
+				"@esbuild/linux-s390x": "0.23.1",
+				"@esbuild/linux-x64": "0.23.1",
+				"@esbuild/netbsd-x64": "0.23.1",
+				"@esbuild/openbsd-arm64": "0.23.1",
+				"@esbuild/openbsd-x64": "0.23.1",
+				"@esbuild/sunos-x64": "0.23.1",
+				"@esbuild/win32-arm64": "0.23.1",
+				"@esbuild/win32-ia32": "0.23.1",
+				"@esbuild/win32-x64": "0.23.1"
 			}
 		},
 		"node_modules/escalade": {
@@ -2760,10 +2902,11 @@
 			}
 		},
 		"node_modules/eslint-plugin-unused-imports": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.1.0.tgz",
-			"integrity": "sha512-9l1YFCzXKkw1qtAru1RWUtG2EVDZY0a0eChKXcL+EZ5jitG7qxdctu4RnvhOJHv4xfmUf7h+JJPINlVpGhZMrw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.2.0.tgz",
+			"integrity": "sha512-6uXyn6xdINEpxE1MtDjxQsyXB37lfyO2yKGVVgtD7WEWQGORSOZjgrD6hBhvGv4/SO+TOlS+UnC6JppRqbuwGQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"eslint-rule-composer": "^0.3.0"
 			},
@@ -2917,7 +3060,8 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
 			"integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
-			"dev": true
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/ext": {
 			"version": "1.7.0",
@@ -2929,28 +3073,96 @@
 			}
 		},
 		"node_modules/fantasticon": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/fantasticon/-/fantasticon-1.2.3.tgz",
-			"integrity": "sha512-VoPXI8+wbLq4qooK2LAFRcqKtOCR20+InF/Io/9I1kLp3IT+LwqJgeFijFvp9a3HRZptfCAxNvazoVHn4kihzQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/fantasticon/-/fantasticon-3.0.0.tgz",
+			"integrity": "sha512-PylulixZA8I0SeiUKtuyOhwrz/ojZTSA1KXddipvEyQXCVrpPMTnSXzaE9nXXK7nCjJWFkqoBAQ1aBdaxMltrg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"change-case": "^4.1.2",
-				"cli-color": "^2.0.0",
-				"commander": "^7.2.0",
-				"glob": "^7.2.0",
-				"handlebars": "^4.7.7",
-				"slugify": "^1.6.0",
+				"case": "^1.6.3",
+				"cli-color": "^2.0.4",
+				"commander": "^12.0.0",
+				"glob": "^10.3.12",
+				"handlebars": "^4.7.8",
+				"slugify": "^1.6.6",
 				"svg2ttf": "^6.0.3",
-				"svgicons2svgfont": "^10.0.3",
-				"ttf2eot": "^2.0.0",
+				"svgicons2svgfont": "^12.0.0",
+				"ttf2eot": "^3.1.0",
 				"ttf2woff": "^3.0.0",
-				"ttf2woff2": "^4.0.4"
+				"ttf2woff2": "^5.0.0"
 			},
 			"bin": {
 				"fantasticon": "bin/fantasticon"
 			},
 			"engines": {
-				"node": ">= 10.0.0"
+				"node": ">= 16.0.0"
+			}
+		},
+		"node_modules/fantasticon/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/fantasticon/node_modules/commander": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/fantasticon/node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/fantasticon/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/fantasticon/node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -3030,6 +3242,7 @@
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
 			"integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"readable-web-to-node-stream": "^3.0.0",
 				"strtok3": "^6.2.4",
@@ -3046,13 +3259,15 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -3125,11 +3340,42 @@
 				}
 			}
 		},
+		"node_modules/foreground-child": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/fs-minipass": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
 			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -3170,7 +3416,9 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
 			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+			"deprecated": "This package is no longer supported.",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"aproba": "^1.0.3 || ^2.0.0",
 				"color-support": "^1.1.3",
@@ -3184,12 +3432,6 @@
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
-		},
-		"node_modules/geometry-interfaces": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/geometry-interfaces/-/geometry-interfaces-1.1.4.tgz",
-			"integrity": "sha512-qD6OdkT6NcES9l4Xx3auTpwraQruU7dARbQPVO71MKvkGYw5/z/oIiGymuFXrRaEQa5Y67EIojUpaLeGEa5hGA==",
-			"dev": true
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
@@ -3220,10 +3462,11 @@
 			}
 		},
 		"node_modules/gifwrap": {
-			"version": "0.9.4",
-			"resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
-			"integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
+			"integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"image-q": "^4.0.0",
 				"omggif": "^1.0.10"
@@ -3266,6 +3509,7 @@
 			"resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
 			"integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"min-document": "^2.19.0",
 				"process": "^0.11.10"
@@ -3380,7 +3624,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
@@ -3403,16 +3648,6 @@
 				"he": "bin/he"
 			}
 		},
-		"node_modules/header-case": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-			"dev": true,
-			"dependencies": {
-				"capital-case": "^1.0.4",
-				"tslib": "^2.0.3"
-			}
-		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -3429,7 +3664,8 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
 			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/http-proxy": {
 			"version": "1.18.1",
@@ -3450,6 +3686,7 @@
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
 			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@tootallnate/once": "2",
 				"agent-base": "6",
@@ -3491,6 +3728,7 @@
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
 			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
@@ -3504,6 +3742,7 @@
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
 			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.0.0"
 			}
@@ -3538,7 +3777,8 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.1",
@@ -3554,6 +3794,7 @@
 			"resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
 			"integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "16.9.1"
 			}
@@ -3562,7 +3803,8 @@
 			"version": "16.9.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
 			"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -3594,6 +3836,7 @@
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
 			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -3602,7 +3845,8 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
 			"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
@@ -3625,6 +3869,7 @@
 			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
 			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"jsbn": "1.1.0",
 				"sprintf-js": "^1.1.3"
@@ -3667,7 +3912,8 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
 			"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
@@ -3685,13 +3931,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
 			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -3732,28 +3980,49 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/isarray": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-			"dev": true
-		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
-		"node_modules/jimp": {
-			"version": "0.16.13",
-			"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.16.13.tgz",
-			"integrity": "sha512-Bxz8q7V4rnCky9A0ktTNGA9SkNFVWRHodddI/DaAWZJzF7sVUlFYKQ60y9JGqrKpi48ECA/TnfMzzc5C70VByA==",
+		"node_modules/isomorphic-fetch": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+			"integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"@jimp/custom": "^0.16.13",
-				"@jimp/plugins": "^0.16.13",
-				"@jimp/types": "^0.16.13",
+				"node-fetch": "^2.6.1",
+				"whatwg-fetch": "^3.4.1"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/jimp": {
+			"version": "0.22.12",
+			"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.22.12.tgz",
+			"integrity": "sha512-R5jZaYDnfkxKJy1dwLpj/7cvyjxiclxU3F4TrI/J4j2rS0niq6YDUMoPn5hs8GDpO+OZGo7Ky057CRtWesyhfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jimp/custom": "^0.22.12",
+				"@jimp/plugins": "^0.22.12",
+				"@jimp/types": "^0.22.12",
 				"regenerator-runtime": "^0.13.3"
 			}
 		},
@@ -3761,7 +4030,8 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
 			"integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -3788,24 +4058,26 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
 			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/jsdoc": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
-			"integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.3.tgz",
+			"integrity": "sha512-Nu7Sf35kXJ1MWDZIMAuATRQTg1iIPdzh7tqJ6jjvaU/GfDf+qi5UV8zJR3Mo+/pYFvm8mzay4+6O5EWigaQBQw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@babel/parser": "^7.20.15",
 				"@jsdoc/salty": "^0.2.1",
-				"@types/markdown-it": "^12.2.3",
+				"@types/markdown-it": "^14.1.1",
 				"bluebird": "^3.7.2",
 				"catharsis": "^0.9.0",
 				"escape-string-regexp": "^2.0.0",
 				"js2xmlparser": "^4.0.2",
 				"klaw": "^3.0.0",
-				"markdown-it": "^12.3.2",
-				"markdown-it-anchor": "^8.4.1",
+				"markdown-it": "^14.1.0",
+				"markdown-it-anchor": "^8.6.7",
 				"marked": "^4.0.10",
 				"mkdirp": "^1.0.4",
 				"requizzle": "^0.2.3",
@@ -3878,26 +4150,28 @@
 			}
 		},
 		"node_modules/linkify-it": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-			"integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"uc.micro": "^1.0.1"
+				"uc.micro": "^2.0.0"
 			}
 		},
 		"node_modules/load-bmfont": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
-			"integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.2.tgz",
+			"integrity": "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"buffer-equal": "0.0.1",
 				"mime": "^1.3.4",
 				"parse-bmfont-ascii": "^1.0.3",
 				"parse-bmfont-binary": "^1.0.5",
 				"parse-bmfont-xml": "^1.1.4",
-				"phin": "^2.9.1",
+				"phin": "^3.7.1",
 				"xhr": "^2.0.1",
 				"xtend": "^4.0.0"
 			}
@@ -3945,20 +4219,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lower-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.0.3"
-			}
-		},
 		"node_modules/lru-cache": {
 			"version": "7.18.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
 			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=12"
 			}
@@ -3977,6 +4243,7 @@
 			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
 			"integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"agentkeepalive": "^4.2.1",
 				"cacache": "^16.1.0",
@@ -4000,19 +4267,21 @@
 			}
 		},
 		"node_modules/markdown-it": {
-			"version": "12.3.2",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-			"integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1",
-				"entities": "~2.1.0",
-				"linkify-it": "^3.0.1",
-				"mdurl": "^1.0.1",
-				"uc.micro": "^1.0.5"
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
 			},
 			"bin": {
-				"markdown-it": "bin/markdown-it.js"
+				"markdown-it": "bin/markdown-it.mjs"
 			}
 		},
 		"node_modules/markdown-it-anchor": {
@@ -4044,10 +4313,11 @@
 			"dev": true
 		},
 		"node_modules/mdurl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-			"dev": true
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/memoizee": {
 			"version": "0.4.15",
@@ -4081,12 +4351,13 @@
 			"dev": true
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -4140,6 +4411,7 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
 			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -4152,6 +4424,7 @@
 			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
 			"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -4164,6 +4437,7 @@
 			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
 			"integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"minipass": "^3.1.6",
 				"minipass-sized": "^1.0.3",
@@ -4181,6 +4455,7 @@
 			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
 			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -4193,6 +4468,7 @@
 			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
 			"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -4205,6 +4481,7 @@
 			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
 			"integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -4217,6 +4494,7 @@
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
 			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"minipass": "^3.0.0",
 				"yallist": "^4.0.0"
@@ -4238,31 +4516,32 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.4.0.tgz",
-			"integrity": "sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==",
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
+			"integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"ansi-colors": "4.1.1",
-				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.3",
-				"debug": "4.3.4",
-				"diff": "5.0.0",
-				"escape-string-regexp": "4.0.0",
-				"find-up": "5.0.0",
-				"glob": "8.1.0",
-				"he": "1.2.0",
-				"js-yaml": "4.1.0",
-				"log-symbols": "4.1.0",
-				"minimatch": "5.0.1",
-				"ms": "2.1.3",
-				"serialize-javascript": "6.0.0",
-				"strip-json-comments": "3.1.1",
-				"supports-color": "8.1.1",
-				"workerpool": "6.2.1",
-				"yargs": "16.2.0",
-				"yargs-parser": "20.2.4",
-				"yargs-unparser": "2.0.0"
+				"ansi-colors": "^4.1.3",
+				"browser-stdout": "^1.3.1",
+				"chokidar": "^3.5.3",
+				"debug": "^4.3.5",
+				"diff": "^5.2.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-up": "^5.0.0",
+				"glob": "^8.1.0",
+				"he": "^1.2.0",
+				"js-yaml": "^4.1.0",
+				"log-symbols": "^4.1.0",
+				"minimatch": "^5.1.6",
+				"ms": "^2.1.3",
+				"serialize-javascript": "^6.0.2",
+				"strip-json-comments": "^3.1.1",
+				"supports-color": "^8.1.1",
+				"workerpool": "^6.5.1",
+				"yargs": "^16.2.0",
+				"yargs-parser": "^20.2.9",
+				"yargs-unparser": "^2.0.0"
 			},
 			"bin": {
 				"_mocha": "bin/_mocha",
@@ -4301,22 +4580,17 @@
 			}
 		},
 		"node_modules/mocha/node_modules/minimatch": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-			"integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/mocha/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
 		},
 		"node_modules/mocha/node_modules/supports-color": {
 			"version": "8.1.1",
@@ -4334,21 +4608,24 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/nan": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
-			"integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
-			"dev": true
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
+			"integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/nanopop": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/nanopop/-/nanopop-2.3.0.tgz",
-			"integrity": "sha512-fzN+T2K7/Ah25XU02MJkPZ5q4Tj5FpjmIYq4rvoHX4yb16HzFdCO6JxFFn5Y/oBhQ8no8fUZavnyIv9/+xkBBw=="
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/nanopop/-/nanopop-2.4.2.tgz",
+			"integrity": "sha512-NzOgmMQ+elxxHeIha+OG/Pv3Oc3p4RU2aBhwWwAqDpXrdTbtRylbRLQztLy8dMMwfl6pclznBdfUhccEn9ZIzw==",
+			"license": "MIT"
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -4356,20 +4633,12 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
-		"node_modules/neatequal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/neatequal/-/neatequal-1.0.0.tgz",
-			"integrity": "sha512-sVt5awO4a4w24QmAthdrCPiVRW3naB8FGLdyadin01BH+6BzNPEBwGrpwCczQvPlULS6uXTItTe1PJ5P0kYm7A==",
-			"dev": true,
-			"dependencies": {
-				"varstream": "^0.3.2"
-			}
-		},
 		"node_modules/negotiator": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
 			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -4401,16 +4670,6 @@
 				"node-gyp-build": "^4.2.2"
 			}
 		},
-		"node_modules/no-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"dev": true,
-			"dependencies": {
-				"lower-case": "^2.0.2",
-				"tslib": "^2.0.3"
-			}
-		},
 		"node_modules/node-addon-api": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
@@ -4418,11 +4677,33 @@
 			"dev": true,
 			"optional": true
 		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/node-gyp": {
 			"version": "9.4.1",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
 			"integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.0",
 				"exponential-backoff": "^3.1.1",
@@ -4460,6 +4741,7 @@
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
 			"integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"abbrev": "^1.0.0"
 			},
@@ -4483,7 +4765,9 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
 			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+			"deprecated": "This package is no longer supported.",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"are-we-there-yet": "^3.0.0",
 				"console-control-strings": "^1.1.0",
@@ -4515,16 +4799,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/occt-import-js": {
-			"version": "0.0.21",
-			"resolved": "https://registry.npmjs.org/occt-import-js/-/occt-import-js-0.0.21.tgz",
-			"integrity": "sha512-na+clmW5OmkEeZDtEVKnQNG9l3GIdEZSCN36lYIt+yJ3OM2MM8t5BYYI9Lrqb7sDPLP/Dt6HkjCNGlEd5JKFgQ=="
-		},
 		"node_modules/omggif": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
 			"integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
@@ -4562,25 +4842,27 @@
 			}
 		},
 		"node_modules/oslllo-potrace": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/oslllo-potrace/-/oslllo-potrace-2.0.1.tgz",
-			"integrity": "sha512-XDsVIUfwXnylngcbecF/6gBHdtFgEnqDt0a9WKqXIo/jPe2AkZkmi6bNaNb9OwlAgoIjy0b1Hi6odPEqztPszg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/oslllo-potrace/-/oslllo-potrace-3.0.0.tgz",
+			"integrity": "sha512-ruH77xpa31SGnXuBJB54XYmlvZnsHlfrUgLFiEK6NxvTgsEZ6IAlfVxOkGnzhJq/73H5Nz9feoa4tLkJRsxYAg==",
 			"dev": true,
+			"license": "GPL-2.0",
 			"dependencies": {
-				"jimp": "^0.16.1"
+				"jimp": "^0.22.12"
 			}
 		},
 		"node_modules/oslllo-svg-fixer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/oslllo-svg-fixer/-/oslllo-svg-fixer-3.0.0.tgz",
-			"integrity": "sha512-fk0oWpDfWlcZI42EJfwZV2a7K2hbB63big8KBCDdIU/72QUeUw2z41hTRO/YJeNyFwixb6ecmwOVdJuWQ6SMLg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/oslllo-svg-fixer/-/oslllo-svg-fixer-5.0.0.tgz",
+			"integrity": "sha512-MhHj7c+w1VajyACTELp9OehnveI0T4P5sSqL5g+urdqAf1dhwOfCpFoLRI16BDYR2EezCPFzKu1TTJG6bXBjFw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-colors": "^4.1.3",
 				"cli-progress": "^3.12.0",
 				"fast-glob": "^3.3.1",
-				"oslllo-potrace": "^2.0.1",
-				"oslllo-svg2": "^2.0.2",
+				"oslllo-potrace": "^3.0.0",
+				"oslllo-svg2": "^3.0.0",
 				"oslllo-validator": "^3.1.0",
 				"piscina": "^4.1.0",
 				"yargs": "^16.2.0"
@@ -4589,27 +4871,19 @@
 				"oslllo-svg-fixer": "src/cli.js"
 			},
 			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/oslllo-svg-fixer/node_modules/ansi-colors": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/oslllo-svg2": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/oslllo-svg2/-/oslllo-svg2-2.0.2.tgz",
-			"integrity": "sha512-Pg1e7op02QaGoUWAuAfORj7TrtJuTXFAOm+5Ycq8iBOvcg/0ZZc3Laxj3Ceh3f9Ad8zmt7qvz90amKPLqXjk7g==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/oslllo-svg2/-/oslllo-svg2-3.0.0.tgz",
+			"integrity": "sha512-XrWzbiR1su45NFWycBoMnN/T/UWY+V+ebe4uoJHTIv0HU9PSJnURZZmtIc2b8wOf0J+WKUhPZuTcmT3WVxybMA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@resvg/resvg-js": "^2.1.0",
 				"domino": "^2.1.6",
-				"jimp": "^0.16.1",
+				"jimp": "^0.22.12",
 				"oslllo-validator": "3.1.0"
 			}
 		},
@@ -4618,6 +4892,7 @@
 			"resolved": "https://registry.npmjs.org/oslllo-validator/-/oslllo-validator-3.1.0.tgz",
 			"integrity": "sha512-eqaVuDxnxDO55+pncqTTphbeq6O5XHMyrSfWQoL48mG2rUjr2ZBzvkFkcxIiG3l7IaIY6/L1oX1AJIDdZyzuPQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"domino": "^2.1.6",
 				"validator": "^13.7.0"
@@ -4661,6 +4936,7 @@
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
 			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"aggregate-error": "^3.0.0"
 			},
@@ -4671,21 +4947,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
 		"node_modules/pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
 			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
 			"dev": true
-		},
-		"node_modules/param-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-			"dev": true,
-			"dependencies": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			}
 		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
@@ -4703,19 +4976,22 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
 			"integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/parse-bmfont-binary": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
 			"integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/parse-bmfont-xml": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
 			"integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"xml-parse-from-string": "^1.0.0",
 				"xml2js": "^0.5.0"
@@ -4725,27 +5001,8 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
 			"integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==",
-			"dev": true
-		},
-		"node_modules/pascal-case": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
 			"dev": true,
-			"dependencies": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/path-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-			"dev": true,
-			"dependencies": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			}
+			"license": "MIT"
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
@@ -4774,11 +5031,46 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/path-scurry/node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
 		"node_modules/peek-readable": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
 			"integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -4788,11 +5080,17 @@
 			}
 		},
 		"node_modules/phin": {
-			"version": "2.9.3",
-			"resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-			"integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==",
-			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-			"dev": true
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
+			"integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"centra": "^2.7.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
@@ -4826,6 +5124,7 @@
 			"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
 			"integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"pngjs": "^3.0.0"
 			},
@@ -4833,13 +5132,24 @@
 				"pixelmatch": "bin/pixelmatch"
 			}
 		},
-		"node_modules/pngjs": {
+		"node_modules/pixelmatch/node_modules/pngjs": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
 			"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/pngjs": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+			"integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.13.0"
 			}
 		},
 		"node_modules/portfinder": {
@@ -4891,6 +5201,7 @@
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
 			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6.0"
 			}
@@ -4899,13 +5210,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
 			"integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/promise-retry": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
 			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"err-code": "^2.0.2",
 				"retry": "^0.12.0"
@@ -4919,6 +5232,16 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -4963,6 +5286,7 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -4986,6 +5310,7 @@
 			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
 			"integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"readable-stream": "^3.6.0"
 			},
@@ -5013,7 +5338,8 @@
 			"version": "0.13.11",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
 			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -5053,6 +5379,7 @@
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -5083,10 +5410,11 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.16.4.tgz",
-			"integrity": "sha512-kuaTJSUbz+Wsb2ATGvEknkI12XV40vIiHmLuFlejoo7HtDok/O5eDDD0UpCVY5bBX5U5RYo8wWP83H7ZsqVEnA==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
+			"integrity": "sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "1.0.5"
 			},
@@ -5098,22 +5426,22 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.16.4",
-				"@rollup/rollup-android-arm64": "4.16.4",
-				"@rollup/rollup-darwin-arm64": "4.16.4",
-				"@rollup/rollup-darwin-x64": "4.16.4",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.16.4",
-				"@rollup/rollup-linux-arm-musleabihf": "4.16.4",
-				"@rollup/rollup-linux-arm64-gnu": "4.16.4",
-				"@rollup/rollup-linux-arm64-musl": "4.16.4",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.16.4",
-				"@rollup/rollup-linux-riscv64-gnu": "4.16.4",
-				"@rollup/rollup-linux-s390x-gnu": "4.16.4",
-				"@rollup/rollup-linux-x64-gnu": "4.16.4",
-				"@rollup/rollup-linux-x64-musl": "4.16.4",
-				"@rollup/rollup-win32-arm64-msvc": "4.16.4",
-				"@rollup/rollup-win32-ia32-msvc": "4.16.4",
-				"@rollup/rollup-win32-x64-msvc": "4.16.4",
+				"@rollup/rollup-android-arm-eabi": "4.21.2",
+				"@rollup/rollup-android-arm64": "4.21.2",
+				"@rollup/rollup-darwin-arm64": "4.21.2",
+				"@rollup/rollup-darwin-x64": "4.21.2",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.21.2",
+				"@rollup/rollup-linux-arm-musleabihf": "4.21.2",
+				"@rollup/rollup-linux-arm64-gnu": "4.21.2",
+				"@rollup/rollup-linux-arm64-musl": "4.21.2",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.21.2",
+				"@rollup/rollup-linux-riscv64-gnu": "4.21.2",
+				"@rollup/rollup-linux-s390x-gnu": "4.21.2",
+				"@rollup/rollup-linux-x64-gnu": "4.21.2",
+				"@rollup/rollup-linux-x64-musl": "4.21.2",
+				"@rollup/rollup-win32-arm64-msvc": "4.21.2",
+				"@rollup/rollup-win32-ia32-msvc": "4.21.2",
+				"@rollup/rollup-win32-x64-msvc": "4.21.2",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -5177,13 +5505,11 @@
 			"dev": true
 		},
 		"node_modules/semver": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -5191,34 +5517,12 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/semver/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/sentence-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-			"dev": true,
-			"dependencies": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
-			}
-		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
@@ -5227,7 +5531,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
@@ -5289,7 +5594,8 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/slugify": {
 			"version": "1.6.6",
@@ -5305,19 +5611,10 @@
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/snake-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-			"dev": true,
-			"dependencies": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/socks": {
@@ -5325,6 +5622,7 @@
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
 			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ip-address": "^9.0.5",
 				"smart-buffer": "^4.2.0"
@@ -5339,6 +5637,7 @@
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
 			"integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"agent-base": "^6.0.2",
 				"debug": "^4.3.3",
@@ -5370,13 +5669,15 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
 			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/ssri": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
 			"integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.1.1"
 			},
@@ -5427,11 +5728,41 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -5456,6 +5787,7 @@
 			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
 			"integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0",
 				"peek-readable": "^4.1.0"
@@ -5485,6 +5817,7 @@
 			"resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
 			"integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12.0.0"
 			}
@@ -5507,31 +5840,84 @@
 			}
 		},
 		"node_modules/svgicons2svgfont": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-10.0.6.tgz",
-			"integrity": "sha512-fUgQEVg3XwTbOHvlXahHGqCet5Wvfo1bV4DCvbSRvjsOCPCRunYbG4dUJCPegps37BMph3eOrfoobhH5AWuC6A==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-12.0.0.tgz",
+			"integrity": "sha512-fjyDkhiG0M1TPBtZzD12QV3yDcG2fUgiqHPOCYzf7hHE40Hl3GhnE6P1njsJCCByhwM7MiufyDW3L7IOR5dg9w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"commander": "^7.2.0",
-				"geometry-interfaces": "^1.1.4",
-				"glob": "^7.1.6",
-				"neatequal": "^1.0.0",
-				"readable-stream": "^3.4.0",
+				"commander": "^9.3.0",
+				"glob": "^8.0.3",
 				"sax": "^1.2.4",
-				"svg-pathdata": "^6.0.0"
+				"svg-pathdata": "^6.0.3"
 			},
 			"bin": {
 				"svgicons2svgfont": "bin/svgicons2svgfont.js"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=16.15.0"
+			}
+		},
+		"node_modules/svgicons2svgfont/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/svgicons2svgfont/node_modules/commander": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || >=14"
+			}
+		},
+		"node_modules/svgicons2svgfont/node_modules/glob": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/svgicons2svgfont/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/svgo": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
-			"integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
+			"integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@trysound/sax": "0.2.0",
 				"commander": "^7.2.0",
@@ -5566,6 +5952,7 @@
 			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
 			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.0.0",
@@ -5583,6 +5970,7 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
 			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=8"
 			}
@@ -5594,9 +5982,10 @@
 			"dev": true
 		},
 		"node_modules/three": {
-			"version": "0.163.0",
-			"resolved": "https://registry.npmjs.org/three/-/three-0.163.0.tgz",
-			"integrity": "sha512-HlMgCb2TF/dTLRtknBnjUTsR8FsDqBY43itYop2+Zg822I+Kd0Ua2vs8CvfBVefXkBdNDrLMoRTGCIIpfCuDew=="
+			"version": "0.168.0",
+			"resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
+			"integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw==",
+			"license": "MIT"
 		},
 		"node_modules/timers-ext": {
 			"version": "0.1.7",
@@ -5612,19 +6001,22 @@
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
 			"integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tinycolor2": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
 			"integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -5637,6 +6029,7 @@
 			"resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
 			"integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0",
 				"ieee754": "^1.2.1"
@@ -5649,39 +6042,25 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
-		"node_modules/tslib": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-			"dev": true
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ttf2eot": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ttf2eot/-/ttf2eot-2.0.0.tgz",
-			"integrity": "sha512-U56aG2Ylw7psLOmakjemAzmpqVgeadwENg9oaDjaZG5NYX4WB6+7h74bNPcc+0BXsoU5A/XWiHabDXyzFOmsxQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ttf2eot/-/ttf2eot-3.1.0.tgz",
+			"integrity": "sha512-aHTbcYosNHVqb2Qtt9Xfta77ae/5y0VfdwNLUS6sGBeGr22cX2JDMo/i5h3uuOf+FAD3akYOr17+fYd5NK8aXw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"argparse": "^1.0.6",
-				"microbuffer": "^1.0.0"
+				"argparse": "^2.0.1"
 			},
 			"bin": {
 				"ttf2eot": "ttf2eot.js"
 			}
-		},
-		"node_modules/ttf2eot/node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
-		"node_modules/ttf2eot/node_modules/sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-			"dev": true
 		},
 		"node_modules/ttf2woff": {
 			"version": "3.0.0",
@@ -5697,11 +6076,12 @@
 			}
 		},
 		"node_modules/ttf2woff2": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/ttf2woff2/-/ttf2woff2-4.0.5.tgz",
-			"integrity": "sha512-zpoU0NopfjoyVqkFeQ722SyKk/n607mm5OHxuDS/wCCSy82B8H3hHXrezftA2KMbKqfJIjie2lsJHdvPnBGbsw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ttf2woff2/-/ttf2woff2-5.0.0.tgz",
+			"integrity": "sha512-FplhShJd3rT8JGa8N04YWQuP7xRvwr9AIq+9/z5O/5ubqNiCADshKl8v51zJDFkhDVcYpdUqUpm7T4M53Z2JoQ==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
 				"bindings": "^1.5.0",
 				"bufferstreams": "^3.0.0",
@@ -5712,7 +6092,7 @@
 				"ttf2woff2": "bin/ttf2woff2.js"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
 			}
 		},
 		"node_modules/type": {
@@ -5746,10 +6126,11 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+			"integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -5759,10 +6140,11 @@
 			}
 		},
 		"node_modules/uc.micro": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-			"dev": true
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/uglify-js": {
 			"version": "3.17.4",
@@ -5784,10 +6166,11 @@
 			"dev": true
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/union": {
 			"version": "0.5.0",
@@ -5806,6 +6189,7 @@
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
 			"integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"unique-slug": "^3.0.0"
 			},
@@ -5818,29 +6202,12 @@
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
 			"integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
-		"node_modules/upper-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/upper-case-first": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/uri-js": {
@@ -5858,13 +6225,14 @@
 			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
 			"dev": true
 		},
-		"node_modules/utif": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
-			"integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
+		"node_modules/utif2": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
+			"integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"pako": "^1.0.5"
+				"pako": "^1.0.11"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -5874,60 +6242,27 @@
 			"dev": true
 		},
 		"node_modules/validator": {
-			"version": "13.11.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
-			"integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+			"version": "13.12.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+			"integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/varstream": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/varstream/-/varstream-0.3.2.tgz",
-			"integrity": "sha512-OpR3Usr9dGZZbDttlTxdviGdxiURI0prX68+DuaN/JfIDbK9ZOmREKM6PgmelsejMnhgjXmEEEgf+E4NbsSqMg==",
-			"dev": true,
-			"dependencies": {
-				"readable-stream": "^1.0.33"
-			},
-			"bin": {
-				"json2varstream": "cli/json2varstream.js",
-				"varstream2json": "cli/varstream2json.js"
-			},
-			"engines": {
-				"node": ">=0.10.*"
-			}
-		},
-		"node_modules/varstream/node_modules/readable-stream": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-			"integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
-				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
-			}
-		},
-		"node_modules/varstream/node_modules/string_decoder": {
-			"version": "0.10.31",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+		"node_modules/web-ifc": {
+			"version": "0.0.57",
+			"resolved": "https://registry.npmjs.org/web-ifc/-/web-ifc-0.0.57.tgz",
+			"integrity": "sha512-ozzfxiCNT4+VqIhm93QdTozOmkMSPRZzf1RoRMMQIQLqoidYdExnAmY1OLoq1emnbvHPqFNQJ5HnQoqxvYZeFA==",
 			"dev": true
 		},
-		"node_modules/web-ifc": {
-			"version": "0.0.44",
-			"resolved": "https://registry.npmjs.org/web-ifc/-/web-ifc-0.0.44.tgz",
-			"integrity": "sha512-1Iz0zeYFVReE3ca72wIqCQeMQX3406ohJGcZrpnS3IevtKjqh7kLXJ5SrSW4C0IyaLhuLIuyLOFsBc6TeD38TA==",
-			"dependencies": {
-				"web-ifc": "^0.0.43"
-			}
-		},
-		"node_modules/web-ifc/node_modules/web-ifc": {
-			"version": "0.0.43",
-			"resolved": "https://registry.npmjs.org/web-ifc/-/web-ifc-0.0.43.tgz",
-			"integrity": "sha512-83rMzZTCZmlACjWYuZRci4GlaWh0hfoTJu/7VKSTOiTm+gAT06fLkIrAqyeOlZnZt/AyY4+IQkPm5RYs6PZPNA=="
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/whatwg-encoding": {
 			"version": "2.0.0",
@@ -5939,6 +6274,24 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-fetch": {
+			"version": "3.6.20",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+			"integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -5961,6 +6314,7 @@
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
 			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
@@ -5981,16 +6335,36 @@
 			"dev": true
 		},
 		"node_modules/workerpool": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-			"integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-			"dev": true
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+			"integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -6014,6 +6388,7 @@
 			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
 			"integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"global": "~4.4.0",
 				"is-function": "^1.0.1",
@@ -6025,13 +6400,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
 			"integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/xml2js": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
 			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"
@@ -6045,6 +6422,7 @@
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
 			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -6060,6 +6438,7 @@
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
 			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.4"
 			}
@@ -6077,7 +6456,8 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",
@@ -6098,10 +6478,11 @@
 			}
 		},
 		"node_modules/yargs-parser": {
-			"version": "20.2.4",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}

--- a/package.json
+++ b/package.json
@@ -57,26 +57,30 @@
 		"build_website": "esbuild source/website/index.js --bundle --minify --global-name=OV --loader:.ttf=file --loader:.woff=file --loader:.svg=file --outfile=build/website/o3dv.website.min.js",
 		"update_engine_exports": "run-python3 tools/update_engine_exports.py"
 	},
+	"engines": {
+		"node": ">=18.0.0",
+		"npm": ">=6.0.0"
+	},
 	"devDependencies": {
-		"@types/node": "^20.1.0",
-		"esbuild": "^0.20.0",
-		"eslint": "^8.29.0",
-		"eslint-plugin-unused-imports": "^3.0.0",
-		"fantasticon": "^1.2.2",
+		"@types/node": "^20.16.5",
+		"esbuild": "^0.23.1",
+		"eslint": "^8.57.0",
+		"eslint-plugin-unused-imports": "^3.2.0",
+		"fantasticon": "^3.0.0",
 		"http-server": "^14.0.0",
-		"jsdoc": "^4.0.0",
-		"mocha": "^10.2.0",
-		"oslllo-svg-fixer": "^3.0.0",
-		"rollup": "^4.0.2",
+		"jsdoc": "^4.0.3",
+		"mocha": "^10.7.3",
+		"oslllo-svg-fixer": "^5.0.0",
+		"rollup": "^4.21.2",
 		"run-python3": "^0.0.5",
-		"svgo": "^3.0.2",
-		"typescript": "^5.0.4",
-		"web-ifc": "0.0.44"
+		"svgo": "^3.3.2",
+		"typescript": "^5.6.2",
+		"web-ifc": "0.0.57"
 	},
 	"dependencies": {
-		"@simonwep/pickr": "1.9.0",
+		"@simonwep/pickr": "1.9.1",
 		"fflate": "0.8.2",
-		"three": "0.163.0"
+		"three": "0.168.0"
 	},
 	"eslintConfig": {
 		"env": {


### PR DESCRIPTION
`npm audit` was showing 10 vulnerabilities (9 moderate, 1 high). This was fixed.

Also, older packages were upgraded. The tests are passing (with the exception of 1, but it's also failing in the `master` branch). I've manually tested the maximum possible in the UI and examples in the locally hosted website, and it's working.
