### PR TITLE
Add support for webp extension texture in gltf importer.

### DIFF
--- a/source/engine/import/importergltf.js
+++ b/source/engine/import/importergltf.js
@@ -271,6 +271,7 @@ class GltfExtensions
             'KHR_draco_mesh_compression',
             'KHR_materials_pbrSpecularGlossiness',
             'KHR_texture_transform',
+            'EXT_texture_webp',
         ];
         this.draco = null;
     }
@@ -752,6 +753,11 @@ export class ImporterGltf extends ImporterBase
         let texture = new TextureMap ();
         let gltfTexture = gltf.textures[gltfTextureRef.index];
         let gltfImageIndex = gltfTexture.source;
+
+        // Handle EXT_texture_webp extension
+        if (gltfTexture.extensions && gltfTexture.extensions.EXT_texture_webp) {
+            gltfImageIndex = gltfTexture.extensions.EXT_texture_webp.source;
+        }
         let gltfImage = gltf.images[gltfImageIndex];
 
         let textureParams = null;


### PR DESCRIPTION
Reason:
I encounted one problem that glb models generated by microsoft trellis 2.0 cannot be loaded. It shows an error:
_Something went wrong
Failed to import model.
Unsupported extension: EXT_texture_webp._
So I decided to fix it.

Summary of Changes:
Added EXT_texture_webp to the list of supported extensions
Added 'EXT_texture_webp' to the supportedExtensions array
Handled the WebP extension in the texture import method
Checked whether the texture uses the EXT_texture_webp extension
If the extension is used, retrieved the correct image index from the extension

How it Works:
The EXT_texture_webp extension allows glTF files to use WebP format textures as an alternative to traditional formats like PNG or JPEG. When a texture object includes this extension, it specifies an alternative image source index that points to a WebP-formatted image.
WebP format is natively supported by browsers, so no additional decoding library is needed.