### PR TITLE
Add animation support for FBX, glTF, and Collada models

### DIFF
--- a/sandbox/animation_test.html
+++ b/sandbox/animation_test.html
@@ -1,0 +1,393 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Animation Test - Online3DViewer</title>
+    <script type="text/javascript" src="../build/engine_dev/o3dv.min.js"></script>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+        }
+        .toolbar {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 12px 16px;
+            background: #16213e;
+            border-bottom: 1px solid #0f3460;
+            flex-wrap: wrap;
+        }
+        .toolbar h1 {
+            font-size: 16px;
+            font-weight: 600;
+            color: #e94560;
+            margin-right: 8px;
+        }
+        .toolbar label {
+            font-size: 13px;
+            cursor: pointer;
+            background: #0f3460;
+            padding: 6px 14px;
+            border-radius: 4px;
+            border: 1px solid #1a3a6a;
+            transition: background 0.2s;
+        }
+        .toolbar label:hover { background: #1a4a7a; }
+        .toolbar input[type="file"] { display: none; }
+        .toolbar select, .toolbar button {
+            font-size: 13px;
+            padding: 6px 12px;
+            border-radius: 4px;
+            border: 1px solid #0f3460;
+            background: #16213e;
+            color: #e0e0e0;
+            cursor: pointer;
+        }
+        .toolbar button {
+            background: #0f3460;
+            transition: background 0.2s;
+        }
+        .toolbar button:hover { background: #1a4a7a; }
+        .toolbar button:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+        .toolbar button.active {
+            background: #e94560;
+            border-color: #e94560;
+        }
+        .time-controls {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        .time-controls input[type="range"] {
+            width: 180px;
+            accent-color: #e94560;
+        }
+        .time-controls span {
+            font-size: 12px;
+            font-family: monospace;
+            min-width: 50px;
+        }
+        #viewer-container {
+            flex: 1;
+            position: relative;
+            overflow: hidden;
+        }
+        #status {
+            padding: 8px 16px;
+            font-size: 12px;
+            font-family: monospace;
+            background: #0f0f23;
+            border-top: 1px solid #0f3460;
+            min-height: 28px;
+        }
+    </style>
+</head>
+<body>
+    <div class="toolbar">
+        <h1>🎬 Animation Test</h1>
+        <label>
+            📂 Load Model
+            <input type="file" id="file-input" multiple
+                accept=".fbx,.glb,.gltf,.dae,.obj,.stl,.3ds,.ply,.off,.3mf,.amf,.wrl,.bim,.ifc,.brep,.step,.stp,.iges,.igs,.3dm,.fcstd">
+        </label>
+        <select id="clip-select" disabled>
+            <option>No animations</option>
+        </select>
+        <button id="btn-play" disabled>▶ Play</button>
+        <button id="btn-pause" disabled>⏸ Pause</button>
+        <button id="btn-stop" disabled>⏹ Stop</button>
+        <div class="time-controls">
+            <input type="range" id="time-slider" min="0" max="100" value="0" step="0.1" disabled>
+            <span id="time-display">0.00s</span>
+        </div>
+    </div>
+    <div id="viewer-container"></div>
+    <div id="debug-log" style="
+        height: 180px;
+        overflow-y: auto;
+        padding: 8px 12px;
+        font-size: 11px;
+        font-family: 'Consolas', 'Monaco', monospace;
+        background: #0a0a1a;
+        border-top: 1px solid #0f3460;
+        line-height: 1.5;
+        color: #8888aa;
+    "></div>
+    <div id="status">Ready — drop or load an animated FBX / glTF / Collada file to test.</div>
+
+    <script>
+        let viewer = null;
+        let currentClipIndex = 0;
+
+        const container = document.getElementById ('viewer-container');
+        const clipSelect = document.getElementById ('clip-select');
+        const btnPlay = document.getElementById ('btn-play');
+        const btnPause = document.getElementById ('btn-pause');
+        const btnStop = document.getElementById ('btn-stop');
+        const timeSlider = document.getElementById ('time-slider');
+        const timeDisplay = document.getElementById ('time-display');
+        const statusBar = document.getElementById ('status');
+        const fileInput = document.getElementById ('file-input');
+        const debugLog = document.getElementById ('debug-log');
+
+        function Log (msg) {
+            statusBar.textContent = msg;
+            console.log ('[status]', msg);
+        }
+
+        function Debug (msg) {
+            let time = new Date ().toLocaleTimeString ();
+            let line = document.createElement ('div');
+            line.textContent = '[' + time + '] ' + msg;
+            debugLog.appendChild (line);
+            debugLog.scrollTop = debugLog.scrollHeight;
+            console.log ('[debug]', msg);
+        }
+
+        function DebugError (msg, err) {
+            let time = new Date ().toLocaleTimeString ();
+            let line = document.createElement ('div');
+            line.style.color = '#e94560';
+            line.textContent = '[' + time + '] ERROR: ' + msg + (err ? ' — ' + (err.message || err) : '');
+            debugLog.appendChild (line);
+            debugLog.scrollTop = debugLog.scrollHeight;
+            console.error ('[debug]', msg, err);
+        }
+
+        // Catch uncaught errors
+        window.addEventListener ('error', (ev) => {
+            DebugError ('Uncaught: ' + ev.message, { message: ev.filename + ':' + ev.lineno });
+        });
+        window.addEventListener ('unhandledrejection', (ev) => {
+            DebugError ('Unhandled promise rejection', ev.reason);
+        });
+
+        function ResetControls () {
+            clipSelect.innerHTML = '<option>No animations</option>';
+            clipSelect.disabled = true;
+            btnPlay.disabled = true;
+            btnPause.disabled = true;
+            btnStop.disabled = true;
+            timeSlider.disabled = true;
+            timeSlider.value = 0;
+            timeDisplay.textContent = '0.00s';
+            btnPlay.classList.remove ('active');
+        }
+
+        function SetupAnimationControls (clips) {
+            clipSelect.innerHTML = '';
+            for (let i = 0; i < clips.length; i++) {
+                let option = document.createElement ('option');
+                option.value = i;
+                let name = clips[i].name || ('Animation ' + i);
+                let duration = clips[i].duration.toFixed (2);
+                option.textContent = name + ' (' + duration + 's)';
+                clipSelect.appendChild (option);
+            }
+            clipSelect.disabled = false;
+            btnPlay.disabled = false;
+            btnStop.disabled = false;
+            timeSlider.disabled = false;
+            timeSlider.max = clips[0].duration;
+            Log ('Found ' + clips.length + ' animation clip(s). Press Play to start.');
+        }
+
+        function LoadFiles (files) {
+            try {
+                Debug ('LoadFiles called with ' + files.length + ' file(s):');
+                for (let i = 0; i < files.length; i++) {
+                    Debug ('  [' + i + '] ' + files[i].name + ' (' + (files[i].size / 1024).toFixed (1) + ' KB)');
+                }
+
+                if (viewer !== null) {
+                    Debug ('Destroying previous viewer...');
+                    viewer.Destroy ();
+                    container.innerHTML = '';
+                }
+                ResetControls ();
+                Log ('Loading model...');
+
+                Debug ('Creating EmbeddedViewer...');
+                viewer = new OV.EmbeddedViewer (container, {
+                    backgroundColor : new OV.RGBAColor (26, 26, 46, 255),
+                    defaultColor : new OV.RGBColor (180, 180, 200),
+                    onModelLoaded : () => {
+                        Debug ('onModelLoaded callback fired.');
+                        let model = viewer.GetModel ();
+                        Debug ('Model meshes: ' + (model ? model.MeshCount () : 'null'));
+
+                        // Inspect Three.js scene materials
+                        let innerViewer = viewer.GetViewer ();
+                        let rootObj = innerViewer.mainModel.mainModel.GetRootObject ();
+                        if (rootObj) {
+                            rootObj.traverse ((obj) => {
+                                if (obj.isMesh || obj.isSkinnedMesh) {
+                                    let mats = Array.isArray (obj.material) ? obj.material : [obj.material];
+                                    for (let mat of mats) {
+                                        Debug ('  Mesh "' + obj.name + '" type=' + obj.type +
+                                            ' mat.type=' + mat.type +
+                                            ' color=#' + (mat.color ? mat.color.getHexString () : 'none') +
+                                            ' emissive=#' + (mat.emissive ? mat.emissive.getHexString () : 'none') +
+                                            ' map=' + (mat.map ? 'yes(' + (mat.map.image ? mat.map.image.width + 'x' + mat.map.image.height : 'no-image') + ')' : 'null') +
+                                            ' opacity=' + mat.opacity +
+                                            ' side=' + mat.side +
+                                            ' visible=' + mat.visible);
+                                    }
+                                }
+                            });
+                        }
+                        Debug ('ShadingType: ' + innerViewer.GetShadingType ());
+
+                        // Scene dump
+                        let scene = innerViewer.scene;
+                        Debug ('Scene children: ' + scene.children.length);
+                        scene.children.forEach ((child, i) => {
+                            Debug ('  scene[' + i + '] type=' + child.type + ' name="' + child.name + '"' +
+                                (child.isLight ? ' color=#' + child.color.getHexString () + ' intensity=' + child.intensity.toFixed (2) : '') +
+                                (child.isLight && child.position ? ' pos=(' + child.position.x.toFixed (2) + ',' + child.position.y.toFixed (2) + ',' + child.position.z.toFixed (2) + ')' : ''));
+                        });
+                        let cam = innerViewer.navigation.GetCamera ();
+                        Debug ('Camera eye=(' + cam.eye.x.toFixed (2) + ',' + cam.eye.y.toFixed (2) + ',' + cam.eye.z.toFixed (2) + ')' +
+                            ' center=(' + cam.center.x.toFixed (2) + ',' + cam.center.y.toFixed (2) + ',' + cam.center.z.toFixed (2) + ')');
+                        Debug ('Three.Camera near=' + innerViewer.camera.near + ' far=' + innerViewer.camera.far);
+
+                        let clips = viewer.GetAnimationClips ();
+                        Debug ('Animation clips found: ' + clips.length);
+                        for (let i = 0; i < clips.length; i++) {
+                            Debug ('  Clip[' + i + ']: "' + clips[i].name + '" duration=' + clips[i].duration.toFixed (2) + 's tracks=' + clips[i].tracks.length);
+                        }
+                        if (clips.length > 0) {
+                            SetupAnimationControls (clips);
+                        } else {
+                            Log ('Model loaded — no animation clips found in this file.');
+                        }
+                    },
+                    onModelLoadFailed : () => {
+                        DebugError ('onModelLoadFailed callback fired.');
+                        Log ('Failed to load model.');
+                    }
+                });
+
+                Debug ('Calling LoadModelFromFileList...');
+                viewer.LoadModelFromFileList (files);
+                Debug ('LoadModelFromFileList called (async import in progress).');
+            } catch (err) {
+                DebugError ('Exception in LoadFiles', err);
+            }
+        }
+
+        fileInput.addEventListener ('change', (ev) => {
+            Debug ('File input change event, files: ' + ev.target.files.length);
+            if (ev.target.files.length > 0) {
+                LoadFiles (ev.target.files);
+            }
+        });
+
+        // Drag-and-drop on entire document body
+        document.body.addEventListener ('dragover', (ev) => {
+            ev.preventDefault ();
+            ev.stopPropagation ();
+        });
+        document.body.addEventListener ('dragenter', (ev) => {
+            ev.preventDefault ();
+            ev.stopPropagation ();
+            container.style.outline = '3px dashed #e94560';
+        });
+        document.body.addEventListener ('dragleave', (ev) => {
+            if (ev.relatedTarget === null || !document.body.contains (ev.relatedTarget)) {
+                container.style.outline = 'none';
+            }
+        });
+        document.body.addEventListener ('drop', (ev) => {
+            ev.preventDefault ();
+            ev.stopPropagation ();
+            container.style.outline = 'none';
+            Debug ('Drop event, files: ' + ev.dataTransfer.files.length);
+            if (ev.dataTransfer.files.length > 0) {
+                LoadFiles (ev.dataTransfer.files);
+            }
+        });
+
+        Debug ('Page loaded. OV namespace available: ' + (typeof OV !== 'undefined'));
+        Debug ('OV.EmbeddedViewer: ' + (typeof OV !== 'undefined' && typeof OV.EmbeddedViewer));
+        Debug ('OV.RGBAColor: ' + (typeof OV !== 'undefined' && typeof OV.RGBAColor));
+
+        clipSelect.addEventListener ('change', () => {
+            currentClipIndex = parseInt (clipSelect.value, 10);
+            let clips = viewer.GetAnimationClips ();
+            timeSlider.max = clips[currentClipIndex].duration;
+            if (viewer.IsAnimationPlaying ()) {
+                viewer.PlayAnimation (currentClipIndex);
+            }
+        });
+
+        btnPlay.addEventListener ('click', () => {
+            if (viewer === null) { return; }
+            if (viewer.IsAnimationPlaying ()) {
+                return;
+            }
+            let clips = viewer.GetAnimationClips ();
+            if (clips.length === 0) { return; }
+            viewer.PlayAnimation (currentClipIndex);
+            btnPlay.classList.add ('active');
+            Log ('Playing: ' + (clips[currentClipIndex].name || 'Animation ' + currentClipIndex));
+        });
+
+        btnPause.addEventListener ('click', () => {
+            if (viewer === null) { return; }
+            if (viewer.IsAnimationPlaying ()) {
+                viewer.PauseAnimation ();
+                btnPlay.classList.remove ('active');
+                Log ('Paused.');
+            } else {
+                viewer.ResumeAnimation ();
+                btnPlay.classList.add ('active');
+                Log ('Resumed.');
+            }
+            btnPause.disabled = false;
+        });
+
+        btnStop.addEventListener ('click', () => {
+            if (viewer === null) { return; }
+            viewer.StopAnimation ();
+            btnPlay.classList.remove ('active');
+            timeSlider.value = 0;
+            timeDisplay.textContent = '0.00s';
+            Log ('Stopped.');
+        });
+
+        timeSlider.addEventListener ('input', () => {
+            if (viewer === null) { return; }
+            let time = parseFloat (timeSlider.value);
+            viewer.SetAnimationTime (time);
+            timeDisplay.textContent = time.toFixed (2) + 's';
+        });
+
+        // Update time slider during playback
+        setInterval (() => {
+            if (viewer !== null && viewer.IsAnimationPlaying ()) {
+                let clips = viewer.GetAnimationClips ();
+                let innerViewer = viewer.GetViewer ();
+                if (innerViewer.animationMixer !== null) {
+                    let time = innerViewer.animationMixer.time;
+                    let duration = clips[currentClipIndex].duration;
+                    let displayTime = time % duration;
+                    timeSlider.value = displayTime;
+                    timeDisplay.textContent = displayTime.toFixed (2) + 's';
+                }
+                btnPause.disabled = false;
+            }
+        }, 100);
+    </script>
+</body>
+</html>

--- a/source/engine/import/importer.js
+++ b/source/engine/import/importer.js
@@ -53,6 +53,8 @@ export class ImportResult
         this.upVector = null;
         this.usedFiles = null;
         this.missingFiles = null;
+        this.animationClips = [];
+        this.threeObject = null;
     }
 }
 
@@ -233,6 +235,8 @@ export class Importer
                 result.usedFiles = this.usedFiles;
                 result.missingFiles = this.missingFiles;
                 result.upVector = importer.GetUpDirection ();
+                result.animationClips = importer.GetAnimationClips ();
+                result.threeObject = importer.GetThreeObject ();
                 callbacks.onImportSuccess (result);
             },
             onError : () => {

--- a/source/engine/import/importerbase.js
+++ b/source/engine/import/importerbase.js
@@ -97,6 +97,16 @@ export class ImporterBase
         return this.model;
     }
 
+    GetAnimationClips ()
+    {
+        return [];
+    }
+
+    GetThreeObject ()
+    {
+        return null;
+    }
+
     SetError (message)
     {
         this.error = true;

--- a/source/engine/import/importerthree.js
+++ b/source/engine/import/importerthree.js
@@ -46,6 +46,8 @@ export class ImporterThreeBase extends ImporterBase
         this.loader = null;
         this.materialIdToIndex = null;
         this.objectUrlToFileName = null;
+        this.animationClips = null;
+        this.threeObject = null;
     }
 
     ResetContent ()
@@ -53,6 +55,8 @@ export class ImporterThreeBase extends ImporterBase
         this.loader = null;
         this.materialIdToIndex = new Map ();
         this.objectUrlToFileName = new Map ();
+        this.animationClips = [];
+        this.threeObject = null;
     }
 
     ImportContent (fileContent, onFinish)
@@ -142,6 +146,13 @@ export class ImporterThreeBase extends ImporterBase
         }
 
         let mainObject = this.GetMainObject (loadedObject);
+
+        let animations = loadedObject.animations || mainObject.animations || [];
+        if (animations.length > 0) {
+            this.animationClips = animations;
+            this.threeObject = mainObject;
+        }
+
         let rootNode = this.model.GetRootNode ();
         rootNode.SetTransformation (GetObjectTransformation (mainObject));
         for (let childObject of mainObject.children) {
@@ -280,6 +291,16 @@ export class ImporterThreeBase extends ImporterBase
             threeColor = this.colorConverter.Convert (threeColor);
         }
         return ConvertThreeColorToColor (threeColor);
+    }
+
+    GetAnimationClips ()
+    {
+        return this.animationClips || [];
+    }
+
+    GetThreeObject ()
+    {
+        return this.threeObject || null;
     }
 }
 

--- a/source/engine/threejs/threemodelloader.js
+++ b/source/engine/threejs/threemodelloader.js
@@ -53,6 +53,7 @@ export class ThreeModelLoader
             },
             onImportSuccess : (importResult) => {
                 callbacks.onVisualizationStart ();
+                let hasAnimations = importResult.animationClips.length > 0 && importResult.threeObject !== null;
                 let params = new ModelToThreeConversionParams ();
                 params.forceMediumpForMaterials = this.hasHighpDriverIssue;
                 let output = new ModelToThreeConversionOutput ();
@@ -63,14 +64,18 @@ export class ThreeModelLoader
                     onModelLoaded : (threeObject) => {
                         this.defaultMaterials = output.defaultMaterials;
                         this.objectUrls = output.objectUrls;
+                        let renderObject = hasAnimations ? importResult.threeObject : threeObject;
+                        if (hasAnimations) {
+                            this.CleanupBrokenTextures (renderObject);
+                        }
                         if (importResult.upVector === Direction.X) {
                             let rotation = new THREE.Quaternion ().setFromAxisAngle (new THREE.Vector3 (0.0, 0.0, 1.0), Math.PI / 2.0);
-                            threeObject.quaternion.multiply (rotation);
+                            renderObject.quaternion.multiply (rotation);
                         } else if (importResult.upVector === Direction.Z) {
                             let rotation = new THREE.Quaternion ().setFromAxisAngle (new THREE.Vector3 (1.0, 0.0, 0.0), -Math.PI / 2.0);
-                            threeObject.quaternion.multiply (rotation);
+                            renderObject.quaternion.multiply (rotation);
                         }
-                        callbacks.onModelFinished (importResult, threeObject);
+                        callbacks.onModelFinished (importResult, renderObject);
                         this.inProgress = false;
                     }
                 });
@@ -105,6 +110,24 @@ export class ThreeModelLoader
                 }
             }
         }
+    }
+
+    CleanupBrokenTextures (object)
+    {
+        let textureProps = ['map', 'normalMap', 'bumpMap', 'emissiveMap', 'specularMap', 'aoMap'];
+        object.traverse ((obj) => {
+            if (obj.isMesh) {
+                let materials = Array.isArray (obj.material) ? obj.material : [obj.material];
+                for (let material of materials) {
+                    for (let prop of textureProps) {
+                        if (material[prop] && (!material[prop].image || material[prop].image.width === 0)) {
+                            material[prop] = null;
+                            material.needsUpdate = true;
+                        }
+                    }
+                }
+            }
+        });
     }
 
     RevokeObjectUrls ()

--- a/source/engine/viewer/embeddedviewer.js
+++ b/source/engine/viewer/embeddedviewer.js
@@ -160,6 +160,9 @@ export class EmbeddedViewer
                 }
 
                 this.model = importResult.model;
+                if (importResult.animationClips && importResult.animationClips.length > 0) {
+                    this.viewer.SetAnimationClips (threeObject, importResult.animationClips);
+                }
                 if (this.parameters.onModelLoaded) {
                     this.parameters.onModelLoaded ();
                 }
@@ -203,6 +206,66 @@ export class EmbeddedViewer
     GetModel ()
     {
         return this.model;
+    }
+
+    /**
+     * Returns the list of animation clips available in the loaded model.
+     * @returns {THREE.AnimationClip[]} Array of animation clips, or empty array if none.
+     */
+    GetAnimationClips ()
+    {
+        return this.viewer.GetAnimationClips ();
+    }
+
+    /**
+     * Plays the animation clip at the given index.
+     * @param {number} index Index of the animation clip to play.
+     */
+    PlayAnimation (index)
+    {
+        this.viewer.PlayAnimation (index);
+    }
+
+    /**
+     * Pauses the currently playing animation.
+     */
+    PauseAnimation ()
+    {
+        this.viewer.PauseAnimation ();
+    }
+
+    /**
+     * Resumes a paused animation.
+     */
+    ResumeAnimation ()
+    {
+        this.viewer.ResumeAnimation ();
+    }
+
+    /**
+     * Stops the currently playing animation and resets playback.
+     */
+    StopAnimation ()
+    {
+        this.viewer.StopAnimation ();
+    }
+
+    /**
+     * Sets the animation playback to a specific time in seconds.
+     * @param {number} time Time in seconds.
+     */
+    SetAnimationTime (time)
+    {
+        this.viewer.SetAnimationTime (time);
+    }
+
+    /**
+     * Returns whether an animation is currently playing.
+     * @returns {boolean}
+     */
+    IsAnimationPlaying ()
+    {
+        return this.viewer.IsAnimationPlaying ();
     }
 
     /**

--- a/source/engine/viewer/viewer.js
+++ b/source/engine/viewer/viewer.js
@@ -56,8 +56,9 @@ export function GetShadingTypeOfObject (mainObject)
     let shadingType = null;
     TraverseThreeObject (mainObject, (obj) => {
         if (obj.isMesh) {
-            for (const material of obj.material) {
-                if (material.type === 'MeshPhongMaterial') {
+            let materials = Array.isArray (obj.material) ? obj.material : [obj.material];
+            for (const material of materials) {
+                if (material.type === 'MeshPhongMaterial' || material.type === 'MeshLambertMaterial') {
                     shadingType = ShadingType.Phong;
                 } else if (material.type === 'MeshStandardMaterial') {
                     shadingType = ShadingType.Physical;
@@ -175,6 +176,12 @@ export class Viewer
         this.settings = {
             animationSteps : 40
         };
+
+        this.animationMixer = null;
+        this.animationClips = [];
+        this.animationClock = null;
+        this.isAnimationPlaying = false;
+        this.animationFrameId = null;
     }
 
     Init (canvas)
@@ -427,6 +434,118 @@ export class Viewer
         this.Render ();
     }
 
+    SetAnimationClips (object, clips)
+    {
+        this.ClearAnimation ();
+        if (!clips || clips.length === 0) {
+            return;
+        }
+        this.animationClips = clips;
+        this.animationMixer = new THREE.AnimationMixer (object);
+        this.animationClock = new THREE.Clock (false);
+    }
+
+    GetAnimationClips ()
+    {
+        return this.animationClips;
+    }
+
+    PlayAnimation (index)
+    {
+        if (this.animationMixer === null || index < 0 || index >= this.animationClips.length) {
+            return;
+        }
+        this.animationMixer.stopAllAction ();
+        let clip = this.animationClips[index];
+        let action = this.animationMixer.clipAction (clip);
+        action.play ();
+        this.animationClock.start ();
+        this.isAnimationPlaying = true;
+        this.StartAnimationLoop ();
+    }
+
+    PauseAnimation ()
+    {
+        if (this.animationMixer === null) {
+            return;
+        }
+        this.isAnimationPlaying = false;
+        this.animationClock.stop ();
+        this.StopAnimationLoop ();
+    }
+
+    ResumeAnimation ()
+    {
+        if (this.animationMixer === null || this.isAnimationPlaying) {
+            return;
+        }
+        this.animationClock.start ();
+        this.isAnimationPlaying = true;
+        this.StartAnimationLoop ();
+    }
+
+    StopAnimation ()
+    {
+        if (this.animationMixer === null) {
+            return;
+        }
+        this.animationMixer.stopAllAction ();
+        this.isAnimationPlaying = false;
+        this.animationClock.stop ();
+        this.StopAnimationLoop ();
+        this.Render ();
+    }
+
+    SetAnimationTime (time)
+    {
+        if (this.animationMixer === null) {
+            return;
+        }
+        this.animationMixer.setTime (time);
+        this.Render ();
+    }
+
+    IsAnimationPlaying ()
+    {
+        return this.isAnimationPlaying;
+    }
+
+    StartAnimationLoop ()
+    {
+        if (this.animationFrameId !== null) {
+            return;
+        }
+        let animate = () => {
+            this.animationFrameId = requestAnimationFrame (animate);
+            let delta = this.animationClock.getDelta ();
+            if (delta > 0) {
+                this.animationMixer.update (delta);
+                this.Render ();
+            }
+        };
+        this.animationFrameId = requestAnimationFrame (animate);
+    }
+
+    StopAnimationLoop ()
+    {
+        if (this.animationFrameId !== null) {
+            cancelAnimationFrame (this.animationFrameId);
+            this.animationFrameId = null;
+        }
+    }
+
+    ClearAnimation ()
+    {
+        this.StopAnimationLoop ();
+        if (this.animationMixer !== null) {
+            this.animationMixer.stopAllAction ();
+            this.animationMixer = null;
+        }
+        this.animationClips = [];
+        this.animationClock = null;
+        this.isAnimationPlaying = false;
+    }
+
     AddExtraObject (object)
     {
         this.extraModel.AddObject (object);
@@ -435,6 +554,7 @@ export class Viewer
 
     Clear ()
     {
+        this.ClearAnimation ();
         this.mainModel.Clear ();
         this.extraModel.Clear ();
         this.Render ();
@@ -595,6 +715,7 @@ export class Viewer
 
     Destroy ()
     {
+        this.ClearAnimation ();
         this.Clear ();
         this.renderer.dispose ();
     }


### PR DESCRIPTION
Implement a passthrough approach that preserves the original Three.js scene graph for animated models, keeping AnimationClip data that was previously discarded during import.

Changes:
- ImporterThreeBase: Capture loadedObject.animations and original Three.js scene in OnThreeObjectsLoaded
- ImportResult: Extended with animationClips and threeObject fields
- ThreeModelLoader: Use original Three.js scene for animated models, clean up broken texture references before first render
- Viewer: Add THREE.AnimationMixer with requestAnimationFrame render loop, animation control API (Play/Pause/Resume/Stop/Seek)
- EmbeddedViewer: Expose public animation API with JSDoc
- GetShadingTypeOfObject: Handle single materials (SkinnedMesh) and MeshLambertMaterial detection
- New sandbox/animation_test.html for interactive testing