### PR TITLE
Feature: Size Format Toggle in Details Tab (Feet & Inches / Decimal Feet)

### DIFF
--- a/source/website/sidebardetailspanel.js
+++ b/source/website/sidebardetailspanel.js
@@ -34,6 +34,7 @@ export class SidebarDetailsPanel extends SidebarPanel
     constructor (parentDiv)
     {
         super (parentDiv);
+        this.sizeFormatMode = 'default';
     }
 
     GetName ()
@@ -65,9 +66,59 @@ export class SidebarDetailsPanel extends SidebarPanel
         if (unit !== Unit.Unknown) {
             this.AddProperty (table, new Property (PropertyType.Text, Loc ('Unit'), UnitToString (unit)));
         }
-        this.AddProperty (table, new Property (PropertyType.Number, Loc ('Size X'), size.x));
-        this.AddProperty (table, new Property (PropertyType.Number, Loc ('Size Y'), size.y));
-        this.AddProperty (table, new Property (PropertyType.Number, Loc ('Size Z'), size.z));
+        
+        let formatRow = AddDiv (table, 'ov_property_table_row');
+        let formatNameColumn = AddDiv (formatRow, 'ov_property_table_cell ov_property_table_name', Loc ('Size Format') + ':');
+        let formatValueColumn = AddDiv (formatRow, 'ov_property_table_cell ov_property_table_value');
+        let selectElement = document.createElement ('select');
+        selectElement.style.width = '100%';
+        let defaultOption = document.createElement ('option'); defaultOption.value = 'default'; defaultOption.innerHTML = Loc ('Default'); selectElement.appendChild (defaultOption);
+        let feetInchOption = document.createElement ('option'); feetInchOption.value = 'feet_inches'; feetInchOption.innerHTML = Loc ('Feet & Inches'); selectElement.appendChild (feetInchOption);
+        let decFeetOption = document.createElement ('option'); decFeetOption.value = 'decimal_feet'; decFeetOption.innerHTML = Loc ('Decimal Feet'); selectElement.appendChild (decFeetOption);
+        selectElement.value = this.sizeFormatMode;
+        formatValueColumn.appendChild (selectElement);
+
+        let sizeXRow = this.AddProperty (table, new Property (PropertyType.Number, Loc ('Size X'), size.x));
+        let sizeYRow = this.AddProperty (table, new Property (PropertyType.Number, Loc ('Size Y'), size.y));
+        let sizeZRow = this.AddProperty (table, new Property (PropertyType.Number, Loc ('Size Z'), size.z));
+
+        let updateSizes = () => {
+            let format = selectElement.value;
+            this.sizeFormatMode = format;
+            let formatSize = (val) => {
+                if (format === 'default') {
+                    return val.toLocaleString (undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+                }
+                
+                let inches = val;
+                if (unit === Unit.Millimeter) inches = val / 25.4;
+                else if (unit === Unit.Centimeter) inches = val / 2.54;
+                else if (unit === Unit.Meter) inches = val * 39.3700787;
+                else if (unit === Unit.Foot) inches = val * 12.0;
+                else if (unit === Unit.Inch) inches = val;
+                else inches = val * 39.3700787; // User requested default is meters
+                
+                if (format === 'feet_inches') {
+                    if (inches < 12.0) {
+                        return inches.toLocaleString (undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' in';
+                    } else {
+                        let feet = Math.floor (inches / 12.0);
+                        let remInches = inches - (feet * 12.0);
+                        return feet + ' ft ' + remInches.toLocaleString (undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' in';
+                    }
+                } else if (format === 'decimal_feet') {
+                    return (inches / 12.0).toLocaleString (undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' ft';
+                }
+            };
+            
+            sizeXRow.lastChild.innerHTML = formatSize (size.x);
+            sizeYRow.lastChild.innerHTML = formatSize (size.y);
+            sizeZRow.lastChild.innerHTML = formatSize (size.z);
+        };
+        selectElement.addEventListener ('change', updateSizes);
+        if (this.sizeFormatMode !== 'default') {
+            updateSizes ();
+        }
         this.AddCalculatedProperty (table, Loc ('Volume'), () => {
             if (!IsTwoManifold (object3D)) {
                 return null;

--- a/source/website/sidebardetailspanel.js
+++ b/source/website/sidebardetailspanel.js
@@ -66,9 +66,9 @@ export class SidebarDetailsPanel extends SidebarPanel
         if (unit !== Unit.Unknown) {
             this.AddProperty (table, new Property (PropertyType.Text, Loc ('Unit'), UnitToString (unit)));
         }
-        
+
         let formatRow = AddDiv (table, 'ov_property_table_row');
-        let formatNameColumn = AddDiv (formatRow, 'ov_property_table_cell ov_property_table_name', Loc ('Size Format') + ':');
+        AddDiv (formatRow, 'ov_property_table_cell ov_property_table_name', Loc ('Size Format') + ':');
         let formatValueColumn = AddDiv (formatRow, 'ov_property_table_cell ov_property_table_value');
         let selectElement = document.createElement ('select');
         selectElement.style.width = '100%';
@@ -89,15 +89,15 @@ export class SidebarDetailsPanel extends SidebarPanel
                 if (format === 'default') {
                     return val.toLocaleString (undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
                 }
-                
-                let inches = val;
+
+                let inches
                 if (unit === Unit.Millimeter) inches = val / 25.4;
                 else if (unit === Unit.Centimeter) inches = val / 2.54;
                 else if (unit === Unit.Meter) inches = val * 39.3700787;
                 else if (unit === Unit.Foot) inches = val * 12.0;
                 else if (unit === Unit.Inch) inches = val;
                 else inches = val * 39.3700787; // User requested default is meters
-                
+
                 if (format === 'feet_inches') {
                     if (inches < 12.0) {
                         return inches.toLocaleString (undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' in';
@@ -110,7 +110,7 @@ export class SidebarDetailsPanel extends SidebarPanel
                     return (inches / 12.0).toLocaleString (undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' ft';
                 }
             };
-            
+
             sizeXRow.lastChild.innerHTML = formatSize (size.x);
             sizeYRow.lastChild.innerHTML = formatSize (size.y);
             sizeZRow.lastChild.innerHTML = formatSize (size.z);


### PR DESCRIPTION
# Feature: Size Format Toggle in Details Tab (Feet & Inches / Decimal Feet)

## Description
This PR introduces a new **Size Format** dropdown in the Sidebar Details Panel that allows users to quickly convert the X, Y, and Z bounding box dimensions of selected objects into imperial units on the fly. 

**Key additions include:**
* A dropdown selector allowing users to switch between three states:
  * **Default**: The standard, raw numeric output in the model's native base unit.
  * **Feet & Inches**: Converts the dimensions to `<X> ft <Y> in` (if the dimension exceeds 1 foot) or just `<Y> in` (if under a foot).
  * **Decimal Feet**: Displays the dimension simply as `<X.XX> ft`.
* **State Persistence**: The chosen display format is persisted on the panel instance. When clicking through different objects or groups in the model tree, the sizes will automatically render in the previously selected unit layout.
* **Isolated UI Layer**: Conversions are strictly handled inside the DOM rendering layer of the details tab, ensuring that actual model coordinates, bounding box caches, and mathematical measuring tools are unaffected.

## How It Works
The converter checks the model's base unit (via `model.GetUnit()`). If it's a known metric or imperial unit, it mathematically scales the bounding box values (`size.x`, `size.y`, `size.z`) into total inches, and then string formats them based on the selected dropdown mode.

## Circumstances & Caveats

### When it works perfectly:
This feature works flawlessly when the 3D model contains explicit metadata defining its real-world scale (its base unit). In these scenarios, the math is precise regardless of what unit the file was created in.

**Best Supported File Types:**
* **glTF / GLB:** The glTF specification strictly mandates that 1 unit = 1 Meter. This will always convert accurately.
* **IFC:** BIM/Architectural models explicitly define their units.
* **STEP / IGES / 3DM:** Standard CAD formats that embed scale metadata.
* Online 3D Viewer may or may not support some of the listed file types here.

### When it might yield incorrect sizes:
Many older or simpler 3D formats are completely **unitless** (e.g., 1 unit simply means "1 unit" and is interpreted by the host application). When the viewer encounters these files, `model.GetUnit()` registers as `Unknown`.

For this implementation, **when a file's unit is `Unknown`, the fallback assumes the file was modeled in Meters.** 

**Problematic File Types:**
* **STL, OBJ, PLY, 3DS:** These files rarely contain unit definitions. 
  * If a user uploads an architectural OBJ modeled in meters, the conversion will be **100% accurate** (because of our fallback assumption).
  * If a user uploads a 3D printing STL modeled in millimeters (e.g., a 20mm bolt), the script will assume it's 20 *Meters*. Toggling to Feet & Inches will result in the bolt reading as `65 ft 7 in`. 

## Testing Steps
1. Load a `.glb` or `.gltf` model (to guarantee known meter scale).
2. Open the right Sidebar and click the Details tab.
3. Select an object in the scene.
4. Locate the new `Size Format` dropdown right above `Size X`.
5. Toggle between Default, Feet & Inches, and Decimal Feet and verify the math.
6. Select a different object in the model tree and verify that the format persists.
